### PR TITLE
Get RT and QT when they are in objects of type TweetWithVisibilityResults

### DIFF
--- a/twscrape/models.py
+++ b/twscrape/models.py
@@ -189,10 +189,24 @@ class Tweet(JSONTrait):
     def parse(obj: dict, res: dict):
         tw_usr = User.parse(res["users"][obj["user_id_str"]])
 
-        rt_id = _first(obj, ["retweeted_status_id_str", "retweeted_status_result.result.rest_id"])
+        rt_id = _first(
+            obj,
+            [
+                "retweeted_status_id_str",
+                "retweeted_status_result.result.rest_id",
+                "retweeted_status_result.result.tweet.rest_id"
+            ]
+        )
         rt_obj = get_or(res, f"tweets.{rt_id}")
 
-        qt_id = _first(obj, ["quoted_status_id_str", "quoted_status_result.result.rest_id"])
+        qt_id = _first(
+            obj,
+            [
+                "quoted_status_id_str",
+                "quoted_status_result.result.rest_id"
+                "quoted_status_result.result.tweet.rest_id"
+            ]
+        )
         qt_obj = get_or(res, f"tweets.{qt_id}")
 
         doc = Tweet(

--- a/twscrape/models.py
+++ b/twscrape/models.py
@@ -244,12 +244,8 @@ class Tweet(JSONTrait):
         # issue #42 – restore full rt text
         rt = doc.retweetedTweet
         if rt is not None and rt.user is not None and doc.rawContent.endswith("…"):
-            # prefix = f"RT @{rt.user.username}: "
-            # if login changed, old login can be cached in rawContent, so use less strict check
-            prefix = "RT @"
-
-            rt_msg = f"{prefix}{rt.rawContent}"
-            if doc.rawContent != rt_msg and doc.rawContent.startswith(prefix):
+            rt_msg = f"RT @{rt.user.username}: {rt.rawContent}"
+            if doc.rawContent != rt_msg:
                 doc.rawContent = rt_msg
 
         return doc


### PR DESCRIPTION
resolve the same problem than this issue https://github.com/vladkens/twscrape/issues/53 but for tweets with limited replies that must be in `retweetedTweet` and `quotedTweet` keys. Must also resolve this issue: https://github.com/vladkens/twscrape/issues/55

I've also added a correction to RT rawContent reconstruction when truncated. (https://github.com/vladkens/twscrape/issues/74)
In that case top level mentionned users seems to be containing the username so it seems more correct to always use the username found in retweetedTweet.user.username (that also seems to be the new handle).