### PR TITLE
Handle unknown authorization error with status 200

### DIFF
--- a/twscrape/queue_client.py
+++ b/twscrape/queue_client.py
@@ -174,7 +174,6 @@ class QueueClient:
             return  # ignore this error
 
         if rep.status_code == 200 and "Authorization" in msg:
-            await self._close_ctx(-1, banned=True, msg=msg)
             raise UnknownAuthorizationError(msg)
 
         # todo: (32) Could not authenticate you

--- a/twscrape/queue_client.py
+++ b/twscrape/queue_client.py
@@ -174,12 +174,15 @@ class QueueClient:
             return  # ignore this error
 
         if rep.status_code == 200 and "Authorization" in msg:
+            return  # ignore this error
             raise UnknownAuthorizationError(msg)
 
         # todo: (32) Could not authenticate you
 
         if msg != "OK":
-            raise ApiError(rep, res)
+            logger.error(f"Unknown error: {msg}")
+            return # ignore this error
+            #raise ApiError(rep, res)
 
         rep.raise_for_status()
 

--- a/twscrape/queue_client.py
+++ b/twscrape/queue_client.py
@@ -173,7 +173,8 @@ class QueueClient:
         if rep.status_code == 200 and "_Missing: No status found with that ID." in msg:
             return  # ignore this error
 
-        if rep.status_code == 200 and "Authorization: Denied by access control: unspecified reason" in msg:
+        if rep.status_code == 200 and "Authorization" in msg:
+            await self._close_ctx(-1, banned=True, msg=msg)
             raise UnknownAuthorizationError(msg)
 
         # todo: (32) Could not authenticate you


### PR DESCRIPTION
Once again, a small addition to handle a weird api message that i got for certain profiles. I cannot seem to get rid of the error, but now it at least does not break the script.