### PR TITLE
Fixing UTC Error

### DIFF
--- a/twscrape/imap.py
+++ b/twscrape/imap.py
@@ -46,8 +46,10 @@ def _wait_email_code(imap: imaplib.IMAP4_SSL, count: int, min_t: datetime | None
         for x in rep:
             if isinstance(x, tuple):
                 msg = emaillib.message_from_bytes(x[1])
-
-                msg_time = datetime.strptime(msg.get("Date", ""), "%a, %d %b %Y %H:%M:%S %z")
+                try:
+                    msg_time = datetime.strptime(msg.get("Date", "").split(' (')[0], "%a, %d %b %Y %H:%M:%S %z")
+                except ValueError:
+                    msg_time = msg.get("Date", "")
                 msg_from = str(msg.get("From", "")).lower()
                 msg_subj = str(msg.get("Subject", "")).lower()
                 logger.info(f"({i} of {count}) {msg_from} - {msg_time} - {msg_subj}")


### PR DESCRIPTION
While parsing the msg_time object in Hotmail accounts opened in UTC-supporting locations, an error was occurring due to the presence of the (UTC) tag. To prevent errors when encountering this and similar tags, I made an addition that proceeds by splitting with parentheses and taking the first element.

Additionally, I added a try-except block to directly print the string on the screen if an error is encountered.