### PR TITLE
Fixing and improving

### DIFF
--- a/twscrape/login.py
+++ b/twscrape/login.py
@@ -182,7 +182,7 @@ async def login_confirm_email_code(ctx: TaskCtx):
             ctx.imap = await imap_login(ctx.acc.email, ctx.acc.email_password)
 
         now_time = utc.now() - timedelta(seconds=30)
-        value = await imap_get_email_code(ctx.imap, ctx.acc.email, now_time)
+        value = await imap_get_email_code(ctx.imap, ctx.acc.email)
 
     payload = {
         "flow_token": ctx.prev["flow_token"],

--- a/twscrape/queue_client.py
+++ b/twscrape/queue_client.py
@@ -157,10 +157,20 @@ class QueueClient:
             logger.warning(f"Ban detected: {log_msg}")
             await self._close_ctx(-1, inactive=True, msg=err_msg)
             raise HandledError()
+        
+        if err_msg.startswith("(64) Your account is suspended"):
+            logger.warning(f"Ban detected: {log_msg}")
+            await self._close_ctx(-1, inactive=True, msg=err_msg)
+            raise HandledError()
 
         if err_msg.startswith("(32) Could not authenticate you"):
             logger.warning(f"Session expired or banned: {log_msg}")
             await self._close_ctx(-1, inactive=True, msg=err_msg)
+            raise HandledError()
+        
+        if err_msg.startswith("(29) Timeout: Unspecified"):
+            logger.warning(f"Timeout: {log_msg}")
+            await self._close_ctx(-1, inactive=False, msg=err_msg)
             raise HandledError()
 
         if err_msg == "OK" and rep.status_code == 403:


### PR DESCRIPTION
Changed the way of checking for email code, its not based on <time right now, its based on latest email and checking every email for code then trying it (because if x sent a code once it wont send it again while code being still valid) <- in future there should be code exceptions if there are 2 codes to try one if wrong wait for another, im going to look into it in the future.

Preventing scraper to close on unknown errors that can occur frequently. Added 2 new error handlings.