### PR TITLE
Exclude messageprompts as elements

### DIFF
--- a/twscrape/api.py
+++ b/twscrape/api.py
@@ -120,7 +120,7 @@ class API:
 
                 obj = rep.json()
                 els = get_by_path(obj, "entries") or []
-                els = [x for x in els if not x["entryId"].startswith("cursor-")]
+                els = [x for x in els if not (x["entryId"].startswith("cursor-") or x["entryId"].startswith("messageprompt-"))]
                 cur = self._get_cursor(obj, cursor_type)
 
                 rep, cnt, active = self._is_end(rep, queue, els, cur, cnt, limit)


### PR DESCRIPTION
Exclude message prompts from elements to be parsed. Currently they are recognized as elements, but cannot be parsed, which sends the .search-method into an infinite loop. 
Message prompts are informational messages appearing at the top of specific queries, e.g. related to elections. I have attached a danish example:
![image](https://github.com/vladkens/twscrape/assets/685944/4feae15a-60a8-4d38-a982-6bca7778c97c)
