### PR TITLE
fix: Handle zstd encoding

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,7 @@ dev = [
   "pytest-httpx>=0.28.0",
   "pytest>=7.4.4",
   "ruff>=0.1.11",
+  "zstd>=1.5.6.1",
 ]
 
 [project.urls]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,7 @@ dependencies = [
   "httpx>=0.26.0",
   "loguru>=0.7.0",
   "pyotp>=2.9.0",
+  "zstd>=1.5.6.1",
 ]
 
 [project.optional-dependencies]
@@ -36,7 +37,6 @@ dev = [
   "pytest-httpx>=0.28.0",
   "pytest>=7.4.4",
   "ruff>=0.1.11",
-  "zstd>=1.5.6.1",
 ]
 
 [project.urls]

--- a/twscrape/accounts_pool.py
+++ b/twscrape/accounts_pool.py
@@ -116,7 +116,7 @@ class AccountsPool:
             logger.warning("No usernames provided")
             return
 
-        qs = f"""DELETE FROM accounts WHERE username IN ({','.join([f'"{x}"' for x in usernames])})"""
+        qs = f"""DELETE FROM accounts WHERE username IN ({",".join([f'"{x}"' for x in usernames])})"""
         await execute(self._db_file, qs)
 
     async def delete_inactive(self):
@@ -201,7 +201,7 @@ class AccountsPool:
             headers = json_object(),
             cookies = json_object(),
             user_agent = "{UserAgent().safari}"
-        WHERE username IN ({','.join([f'"{x}"' for x in usernames])})
+        WHERE username IN ({",".join([f'"{x}"' for x in usernames])})
         """
 
         await execute(self._db_file, qs)

--- a/twscrape/api.py
+++ b/twscrape/api.py
@@ -3,7 +3,7 @@ from contextlib import aclosing
 from httpx import Response
 from json import loads
 from typing_extensions import deprecated
-from zstd import decompress
+import zstd
 
 from .accounts_pool import AccountsPool
 from .logger import set_log_level
@@ -129,7 +129,7 @@ class API:
                     return
 
                 encoding: str | None = rep.headers.get("content-encoding")
-                obj = loads(decompress(rep.content)) if encoding == "zstd" else rep.json()
+                obj = loads(zstd.decompress(rep.content)) if encoding == "zstd" else rep.json()
                 els = get_by_path(obj, "entries") or []
                 els = [
                     x

--- a/twscrape/api.py
+++ b/twscrape/api.py
@@ -1,9 +1,9 @@
 from contextlib import aclosing
-
-from httpx import Response
 from json import loads
-from typing_extensions import deprecated
+
 import zstd
+from httpx import Response
+from typing_extensions import deprecated
 
 from .accounts_pool import AccountsPool
 from .logger import set_log_level

--- a/twscrape/models.py
+++ b/twscrape/models.py
@@ -135,7 +135,7 @@ class User(JSONTrait):
         return User(
             id=int(obj["id_str"]),
             id_str=obj["id_str"],
-            url=f'https://x.com/{obj["screen_name"]}',
+            url=f"https://x.com/{obj['screen_name']}",
             username=obj["screen_name"],
             displayname=obj["name"],
             rawDescription=obj["description"],
@@ -217,7 +217,7 @@ class Tweet(JSONTrait):
         rt_obj = get_or(res, f"tweets.{_first(obj, rt_id_path)}")
         qt_obj = get_or(res, f"tweets.{_first(obj, qt_id_path)}")
 
-        url = f'https://x.com/{tw_usr.username}/status/{obj["id_str"]}'
+        url = f"https://x.com/{tw_usr.username}/status/{obj['id_str']}"
         doc = Tweet(
             id=int(obj["id_str"]),
             id_str=obj["id_str"],
@@ -507,8 +507,8 @@ def _parse_card(obj: dict, url: str):
 
         options = []
         for x in range(20):
-            label = _parse_card_get_str(val, f"choice{x+1}_label")
-            votes = _parse_card_get_str(val, f"choice{x+1}_count")
+            label = _parse_card_get_str(val, f"choice{x + 1}_label")
+            votes = _parse_card_get_str(val, f"choice{x + 1}_count")
             if label is None or votes is None:
                 break
 

--- a/twscrape/queue_client.py
+++ b/twscrape/queue_client.py
@@ -1,9 +1,9 @@
-from json import JSONDecodeError, dumps, loads
 import os
+from json import JSONDecodeError, dumps, loads
 from typing import Any
-import zstd
 
 import httpx
+import zstd
 from httpx import AsyncClient, Response
 
 from .accounts_pool import Account, AccountsPool
@@ -134,7 +134,7 @@ class QueueClient:
 
         err_msg = "OK"
         if "errors" in res:
-            err_msg = set([f'({x.get("code", -1)}) {x["message"]}' for x in res["errors"]])
+            err_msg = set([f"({x.get('code', -1)}) {x['message']}" for x in res["errors"]])
             err_msg = "; ".join(list(err_msg))
 
         log_msg = f"{rep.status_code:3d} - {req_id(rep)} - {err_msg}"


### PR DESCRIPTION
## Issue description

Sometimes, with big responses, I get the following error:

```
Err: <class 'UnicodeDecodeError'>: 'utf-8' codec can't decode byte 0xb8 in position 1: invalid start byte
```

Fixes: #185 

## Investigation

So I opened my web browser and took a look at the headers.

Request:
```
Accept-Encoding: gzip, deflate, br, zstd
```

Response:
```
content-encoding: zstd
```

Examining the response data shows it was indeed compressed by the zstd algorithm. Because it wasn't handled, it raised a `UnicodeDecodeError` that was catched by the general exception in `queue_client.py` line 38.

## Solution

I added `zstd` to the project dependency and decoded the response content depending on its `content-encoding` header.