### PR TITLE
feat: view explore page trends and search for posts in a trend 

### DIFF
--- a/twscrape/api.py
+++ b/twscrape/api.py
@@ -5,7 +5,7 @@ from typing_extensions import deprecated
 
 from .accounts_pool import AccountsPool
 from .logger import set_log_level
-from .models import Tweet, User, parse_tweet, parse_tweets, parse_user, parse_users
+from .models import Tweet, User, parse_tweet, parse_tweets, parse_user, parse_users, parse_trends
 from .queue_client import QueueClient
 from .utils import encode_params, find_obj, get_by_path
 
@@ -26,7 +26,7 @@ OP_BlueVerifiedFollowers = "srYtCtUs5BuBPbYj7agW6A/BlueVerifiedFollowers"
 OP_UserCreatorSubscriptions = "uFQJ--8sayYPxBqxav4W7A/UserCreatorSubscriptions"
 OP_UserMedia = "BGmkmGDG0kZPM-aoQtNTTw/UserMedia"
 OP_Bookmarks = "fa4kwoT3j5eDJCSKwFDXCw/Bookmarks"
-
+OP_Explore = "5u36Lskx1dfACjC_WHmH3Q/GenericTimelineById"
 
 GQL_URL = "https://x.com/i/api/graphql"
 GQL_FEATURES = {  # search values here (view source) https://x.com/
@@ -69,11 +69,11 @@ class API:
     pool: AccountsPool
 
     def __init__(
-        self,
-        pool: AccountsPool | str | None = None,
-        debug=False,
-        proxy: str | None = None,
-        raise_when_no_account=False,
+            self,
+            pool: AccountsPool | str | None = None,
+            debug=False,
+            proxy: str | None = None,
+            raise_when_no_account=False,
     ):
         if isinstance(pool, AccountsPool):
             self.pool = pool
@@ -107,7 +107,7 @@ class API:
     # gql helpers
 
     async def _gql_items(
-        self, op: str, kv: dict, ft: dict | None = None, limit=-1, cursor_type="Bottom"
+            self, op: str, kv: dict, ft: dict | None = None, limit=-1, cursor_type="Bottom"
     ):
         queue, cur, cnt, active = op.split("/")[-1], None, 0, True
         kv, ft = {**kv}, {**GQL_FEATURES, **(ft or {})}
@@ -132,8 +132,8 @@ class API:
                     x
                     for x in els
                     if not (
-                        x["entryId"].startswith("cursor-")
-                        or x["entryId"].startswith("messageprompt-")
+                            x["entryId"].startswith("cursor-")
+                            or x["entryId"].startswith("messageprompt-")
                     )
                 ]
                 cur = self._get_cursor(obj, cursor_type)
@@ -253,7 +253,7 @@ class API:
             **(kv or {}),
         }
         async with aclosing(
-            self._gql_items(op, kv, limit=limit, cursor_type="ShowMoreThreads")
+                self._gql_items(op, kv, limit=limit, cursor_type="ShowMoreThreads")
         ) as gen:
             async for x in gen:
                 yield x
@@ -346,7 +346,8 @@ class API:
 
     # favoriters
 
-    @deprecated("Likes is no longer available in X, see: https://x.com/XDevelopers/status/1800675411086409765")  # fmt: skip
+    @deprecated(
+        "Likes is no longer available in X, see: https://x.com/XDevelopers/status/1800675411086409765")  # fmt: skip
     async def favoriters_raw(self, twid: int, limit=-1, kv=None):
         op = OP_Favoriters
         kv = {"tweetId": str(twid), "count": 20, "includePromotedContent": True, **(kv or {})}
@@ -354,7 +355,8 @@ class API:
             async for x in gen:
                 yield x
 
-    @deprecated("Likes is no longer available in X, see: https://x.com/XDevelopers/status/1800675411086409765")  # fmt: skip
+    @deprecated(
+        "Likes is no longer available in X, see: https://x.com/XDevelopers/status/1800675411086409765")  # fmt: skip
     async def favoriters(self, twid: int, limit=-1, kv=None):
         async with aclosing(self.favoriters_raw(twid, limit=limit, kv=kv)) as gen:
             async for rep in gen:
@@ -455,9 +457,48 @@ class API:
                 for x in parse_tweets(rep, limit):
                     yield x
 
+    async def list_explore_raw(self, timeline_id: str, kv: dict = None):
+        """
+        :param timeline_id: The ID of the trending timeline you wish to scrape
+                    * 'trending': VGltZWxpbmU6DAC2CwABAAAACHRyZW5kaW5nAAA
+                    * 'news': VGltZWxpbmU6DAC2CwABAAAABG5ld3MAAA
+                    * 'sports': VGltZWxpbmU6DAC2CwABAAAABnNwb3J0cwAA
+                    * 'entertainment': VGltZWxpbmU6DAC2CwABAAAADWVudGVydGFpbm1lbnQAAA
+        :type timeline_id: str
+        """
+        op = OP_Explore
+        kv = {
+            "timelineId": timeline_id,
+            "count": 20,
+            "withQuickPromoteEligibilityTweetFields": True,
+            **(kv or {}),
+        }
+        ft = {
+            "responsive_web_grok_analysis_button_from_backend": False,
+            "responsive_web_grok_image_annotation_enabled": False,
+            "responsive_web_jetfuel_frame": False
+        }
+        return await self._gql_item(op, kv, ft=ft)
+
+    async def list_explore(self, timeline_id: str = None, limit=-1, kv=None):
+        rep = await self.list_explore_raw(timeline_id, kv=kv)
+        for x in parse_trends(rep, limit=limit):
+            yield x
+
+    async def search_trend(self, q: str, limit: int = -1, kv=None):
+        kv = {
+            "querySource": "trend_click",
+            **(kv or {}),
+        }
+        async with aclosing(self.search_raw(q, limit=limit, kv=kv)) as gen:
+            async for rep in gen:
+                for x in parse_tweets(rep.json(), limit):
+                    yield x
+
     # likes
 
-    @deprecated("Likes is no longer available in X, see: https://x.com/XDevelopers/status/1800675411086409765")  # fmt: skip
+    @deprecated(
+        "Likes is no longer available in X, see: https://x.com/XDevelopers/status/1800675411086409765")  # fmt: skip
     async def liked_tweets_raw(self, uid: int, limit=-1, kv=None):
         op = OP_Likes
         kv = {
@@ -472,7 +513,8 @@ class API:
             async for x in gen:
                 yield x
 
-    @deprecated("Likes is no longer available in X, see: https://x.com/XDevelopers/status/1800675411086409765")  # fmt: skip
+    @deprecated(
+        "Likes is no longer available in X, see: https://x.com/XDevelopers/status/1800675411086409765")  # fmt: skip
     async def liked_tweets(self, uid: int, limit=-1, kv=None):
         async with aclosing(self.liked_tweets_raw(uid, limit=limit, kv=kv)) as gen:
             async for rep in gen:

--- a/twscrape/utils.py
+++ b/twscrape/utils.py
@@ -147,7 +147,10 @@ def to_old_rep(obj: dict) -> dict[str, dict]:
     users = [x for x in tmp.get("User", []) if "legacy" in x and "id" in x]
     users = {str(x["rest_id"]): to_old_obj(x) for x in users}
 
-    return {"tweets": {**tw1, **tw2}, "users": users}
+    trends = [x for x in tmp.get("TimelineTrend", [])]
+    trends = {x["name"]: x for x in trends}
+
+    return {"tweets": {**tw1, **tw2}, "users": users, "trends": trends}
 
 
 def print_table(rows: list[dict], hr_after=False):


### PR DESCRIPTION
# Add support for X's Explore Page trending content

This PR adds the ability to fetch trending keywords and hashtags from X's Explore page by querying X's GenericTimelineById endpoint.

## Changes

### twscrape.api

- added the GQL ID and endpoint name

```python
OP_Explore = "5u36Lskx1dfACjC_WHmH3Q/GenericTimelineById"
```

- added methods to attach the appropriate request variables and features and parse trends
```python
async def list_explore_raw(self, timeline_id: str, kv: dict = None)
async def list_explore(self, timeline_id: str = None, limit=-1, kv=None)
``` 

- added a method to search for tweets belonging to a trend by passing ```"querySource": "trend_click"``` to ```twscrape.api.search_raw```
```python
async def search_trend(self, q: str, limit: int = -1, kv=None)
```

### twscrape.utils

- modified ```def to_old_rep(obj: dict) -> dict[str, dict]``` so that it can now parse TimelineTrend items; returns ```{"tweets": {**tw1, **tw2}, "users": users, "trends": trends}```

### twscrape.models

- added methods to parse the response object returned by ```list_explore_raw``` and returns a Generator of TimelineTrend objects

```python
def parse_trends(rep: httpx.Response, limit: int = -1) -> Generator[TimelineTrend, None, None]
def parse_trend(rep: httpx.Response) -> TimelineTrend | None
```

- modified ```parse_items``` so it can now handle a response with TimelineTrend objects

- created a new dataclass ```class TimelineTrend(JSONTrait)```

## Example Usage
```python
async def list_trending(timeline: str = "trending") -> list[TimelineTrend]:
    timeline_to_id: dict = {
        "trending": "VGltZWxpbmU6DAC2CwABAAAACHRyZW5kaW5nAAA=",
        'news': "VGltZWxpbmU6DAC2CwABAAAABG5ld3MAAA==",
        'sports': "VGltZWxpbmU6DAC2CwABAAAABnNwb3J0cwAA",
        'entertainment': "VGltZWxpbmU6DAC2CwABAAAADWVudGVydGFpbm1lbnQAAA=="
    }
    id_ = timeline_to_id[timeline] if timeline in timeline_to_id else "VGltZWxpbmU6DAC2CwABAAAABG5ld3MAAA"
    trends = await gather(api.list_explore(timeline_id=id_))
    return trends


async def search_trending(q: str, product: str = "Top", limit: int = 10) -> list[Tweet]:
    kv: dict = {
        "product": product
    }
    tweets = await gather(
        api.search_trend(q=q, limit=limit, kv=kv)
    )
    return tweets


if __name__ == "__main__":
    # get trending from explore page
    trends = asyncio.run(list_trending("news"))

    # fetch a random trend
    trend: TimelineTrend = random.choice(trends)
    name: str = trend.name

    # fetch tweets
    tweets = asyncio.run(search_trending(q=name, product="Top", limit=25))
    pass
```

## Notes
```list_explore``` requires  a timeline_id as GenericTimelineById allows searching for 4 different timelines categories: trending, news, sports and entertainment. Their various IDs are currently only listed in the ```timeline_to_id``` dictionary in the ```list_trending``` method. I think some mapper from timeline category to ID could be added to the ```list_explore``` method which could then take one of the 4 categories as a parameter. However, this seemed different from how the other methods operated so I decided not to impose this.

I can add this in a modification to this PR if needed !