### PR TITLE
API to get members from List

### DIFF
--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -21,6 +21,7 @@ GQL_GEN = [
     "user_tweets_and_replies",
     "list_timeline",
     "trends",
+    "list_members",
 ]
 
 

--- a/twscrape/api.py
+++ b/twscrape/api.py
@@ -25,6 +25,7 @@ OP_UserCreatorSubscriptions = "7qcGrVKpcooih_VvJLA1ng/UserCreatorSubscriptions"
 OP_UserMedia = "vFPc2LVIu7so2uA_gHQAdg/UserMedia"
 OP_Bookmarks = "-LGfdImKeQz0xS_jjUwzlA/Bookmarks"
 OP_GenericTimelineById = "CT0YFEFf5GOYa5DJcxM91w/GenericTimelineById"
+OP_ListMembers = "CDYIXKGINDLWntNdeXVUgQ"
 
 GQL_URL = "https://x.com/i/api/graphql"
 GQL_FEATURES = {  # search values here (view source) https://x.com/
@@ -514,3 +515,20 @@ class API:
             async for rep in gen:
                 for x in parse_tweets(rep.json(), limit):
                     yield x
+
+    # list members of a List
+
+    async def list_members_raw(self, list_id: int, limit: int = -1, kv: KV = None):
+        # Raw query for list members
+        op = OP_ListMembers
+        kv = {"listId": str(list_id), "count": 20, **(kv or {})}
+        async with aclosing(self._gql_items(op, kv, limit=limit)) as gen:
+            async for page in gen:
+                yield page
+
+    async def list_members(self, list_id: int, limit: int = -1, kv: KV = None):
+        # Parse the list members from the raw query
+        async with aclosing(self.list_members_raw(list_id, limit=limit, kv=kv)) as gen:
+            async for page in gen:
+                for user in parse_users(page.json(), limit):
+                    yield user

--- a/twscrape/cli.py
+++ b/twscrape/cli.py
@@ -196,6 +196,7 @@ def run():
     c_lim("user_media", "Get user's media", "user_id", "User ID", int)
     c_lim("list_timeline", "Get tweets from list", "list_id", "List ID", int)
     c_lim("trends", "Get trends", "trend_id", "Trend ID or name", str)
+    c_lim("list_members", "Get List members by list ID", "list_id", "List ID", int)
 
     args = p.parse_args()
     if args.command is None:


### PR DESCRIPTION
2 new functions **api.list_members_raw** and **api.list_members**  let users retrieve all members of a public Twitter List via the GraphQL API.

"**Lists**" are curated groups of subject matter "experts".
- Ex lists: “Data Scientists,” “Tech Journalists,” “Solana Devs”
- Use Cases: Direct access to curated groups without scraping followers/following feeds.

### Additions
`OP_ListMembers = "CDYIXKGINDLWntNdeXVUgQ"`

Raw Function
`async def list_members_raw(self, list_id: int, limit: int = -1, kv: KV = None):`

Parsed
`async def list_members(self, list_id: int, limit: int = -1, kv: KV = None):
`

Also changes to cli.py and test_api.py for consistency.