### PR TITLE
feat: community scraping

### DIFF
--- a/examples/community_scraping.py
+++ b/examples/community_scraping.py
@@ -1,0 +1,29 @@
+import asyncio
+from twscrape import API
+
+
+async def main():
+    api = API()
+
+    # example community: https://x.com/i/communities/1501272736215322629
+    community_id = "1501272736215322629"
+
+    # community info
+    info = await api.community_info(community_id)
+    print(info.name if info else "Unknown community")
+
+    # members
+    async for user in api.community_members(community_id, limit=5):
+        print(f"member @{user.username} - {user.displayname}")
+
+    # moderators
+    async for user in api.community_moderators(community_id, limit=10):
+        print(f"moderator @{user.username} - {user.displayname}")
+
+    # tweets
+    async for tweet in api.community_tweets(community_id, limit=5):
+        print(f"tweet {tweet.id} by @{tweet.user.username}: {tweet.rawContent[:100]}...")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/readme.md
+++ b/readme.md
@@ -100,6 +100,13 @@ async def main():
     # list info
     await gather(api.list_timeline(list_id=123456789))
 
+    # community info
+    community_id = "1501272736215322629"
+    await api.community_info(community_id)  # Community
+    await gather(api.community_members(community_id, limit=20))  # list[User]
+    await gather(api.community_moderators(community_id, limit=20))  # list[User]
+    await gather(api.community_tweets(community_id, limit=20))  # list[Tweet]
+
     # trends
     await gather(api.trends("news"))  # list[Trend]
     await gather(api.trends("sport"))  # list[Trend]
@@ -254,6 +261,9 @@ twscrape verified_followers USER_ID --limit=20
 twscrape subscriptions USER_ID --limit=20
 twscrape user_tweets USER_ID --limit=20
 twscrape user_tweets_and_replies USER_ID --limit=20
+twscrape community_members COMMUNITY_ID --limit=20
+twscrape community_moderators COMMUNITY_ID --limit=20
+twscrape community_tweets COMMUNITY_ID --limit=20
 twscrape trends sport
 ```
 

--- a/twscrape/cli.py
+++ b/twscrape/cli.py
@@ -23,7 +23,7 @@ class CustomHelpFormatter(argparse.HelpFormatter):
 
 
 def get_fn_arg(args):
-    names = ["query", "tweet_id", "user_id", "username", "list_id", "trend_id"]
+    names = ["query", "tweet_id", "user_id", "username", "list_id", "trend_id", "community_id"]
     for name in names:
         if name in args:
             return name, getattr(args, name)
@@ -195,6 +195,9 @@ def run():
     c_lim("user_tweets_and_replies", "Get user tweets and replies", "user_id", "User ID", int)
     c_lim("user_media", "Get user's media", "user_id", "User ID", int)
     c_lim("list_timeline", "Get tweets from list", "list_id", "List ID", int)
+    c_lim("community_members", "Get community members", "community_id", "Community ID", str)
+    c_lim("community_moderators", "Get community moderators", "community_id", "Community ID", str)
+    c_lim("community_tweets", "Get community tweets", "community_id", "Community ID", str)
     c_lim("trends", "Get trends", "trend_id", "Trend ID or name", str)
 
     args = p.parse_args()


### PR DESCRIPTION
This adds  community endpoints (`community_info`, `community_members`, `community_moderators`, `community_tweets` + raw variants) and CLI flags.

I had to tweak the parser so community member responses with missing fields still parse cleanly.

To test, run `examples/community_scraping.py`

--- 

Example trimmed response:
```
{
    "id": 1501272736215322629,
    "id_str": "1501272736215322629",
    "name": "New York Mets",
    "description": "Your baseball source for all Mets news, updates, in-game highlights and content. For Mets fans by Mets fans #LGM",
    "memberCount": 27105,
    "moderatorCount": 0,
    "rules": [
      {"id_str": "1501272736383090692", "name": "Keep Tweets on topic.", "description": ""},
      {"id_str": "1521944352750280704", "name": "No Trolls", "description": ""},
      {"id_str": "1877106707501035784", "name": "No Politics", "description": ""},
      {"id_str": "1939637317636858332", "name": "No Hate Speech/Slurs", "description": "Ridiculous that this needed to be added. You will be banned"}
    ],
    "topicId": null,
    "topicName": "Baseball",
    "isNsfw": false
  }
```
  And a typical member item from community_members:
```
  {
    "community_role": "Member",
    "rest_id": "1118575978169737217",
    "core": {"screen_name": "GottaBelievePod", "name": "We Gotta Believe"},
    "legacy": {...minimal legacy fields...}
  }
```

  Closes #273.