### PR TITLE
fix: handle malformed JSON in get_scripts_list

### DIFF
--- a/tests/test_xclid.py
+++ b/tests/test_xclid.py
@@ -1,0 +1,25 @@
+
+import pytest
+from twscrape.xclid import get_scripts_list
+
+def test_get_scripts_list_malformed_json():
+    # Test case with malformed JSON (unquoted keys)
+    malformed_text_content = 'node_modules_pnpm_ws_8_18_0_node_modules_ws_browser_js:"12345",other_key:"67890"'
+    malformed_text = 'stuff... e=>e+"."+' + '{' + malformed_text_content + '}' + '[e]+"a.js"... stuff'
+    
+    scripts = list(get_scripts_list(malformed_text))
+    
+    assert len(scripts) == 2
+    assert "https://abs.twimg.com/responsive-web/client-web/node_modules_pnpm_ws_8_18_0_node_modules_ws_browser_js.12345a.js" in scripts
+    assert "https://abs.twimg.com/responsive-web/client-web/other_key.67890a.js" in scripts
+
+def test_get_scripts_list_normal_json():
+    # Test case with normal JSON (quoted keys)
+    normal_text_content = '"normal_key":"12345","another_key":"67890"'
+    normal_text = 'stuff... e=>e+"."+' + '{' + normal_text_content + '}' + '[e]+"a.js"... stuff'
+    
+    scripts = list(get_scripts_list(normal_text))
+    
+    assert len(scripts) == 2
+    assert "https://abs.twimg.com/responsive-web/client-web/normal_key.12345a.js" in scripts
+    assert "https://abs.twimg.com/responsive-web/client-web/another_key.67890a.js" in scripts

--- a/tests/test_xclid.py
+++ b/tests/test_xclid.py
@@ -3,15 +3,16 @@ import pytest
 from twscrape.xclid import get_scripts_list
 
 def test_get_scripts_list_malformed_json():
-    # Test case with malformed JSON (unquoted keys)
-    malformed_text_content = 'node_modules_pnpm_ws_8_18_0_node_modules_ws_browser_js:"12345",other_key:"67890"'
+    # Test case with various malformed JSON (unquoted keys, including no underscores and numeric)
+    malformed_text_content = 'node_modules_pnpm_ws_8_18_0_node_modules_ws_browser_js:"12345",runtime:"67890",999:"000"'
     malformed_text = 'stuff... e=>e+"."+' + '{' + malformed_text_content + '}' + '[e]+"a.js"... stuff'
     
     scripts = list(get_scripts_list(malformed_text))
     
-    assert len(scripts) == 2
+    assert len(scripts) == 3
     assert "https://abs.twimg.com/responsive-web/client-web/node_modules_pnpm_ws_8_18_0_node_modules_ws_browser_js.12345a.js" in scripts
-    assert "https://abs.twimg.com/responsive-web/client-web/other_key.67890a.js" in scripts
+    assert "https://abs.twimg.com/responsive-web/client-web/runtime.67890a.js" in scripts
+    assert "https://abs.twimg.com/responsive-web/client-web/999.000a.js" in scripts
 
 def test_get_scripts_list_normal_json():
     # Test case with normal JSON (quoted keys)

--- a/twscrape/xclid.py
+++ b/twscrape/xclid.py
@@ -52,7 +52,18 @@ def get_scripts_list(text: str):
         for k, v in json.loads(scripts).items():
             yield script_url(k, f"{v}a")
     except json.decoder.JSONDecodeError as e:
-        raise Exception("Failed to parse scripts") from e
+        # Fix unquoted keys like: node_modules_pnpm_ws_8_18_0_node_modules_ws_browser_js
+        # Twitter started returning malformed JSON with unquoted keys
+        try:
+            fixed_scripts = re.sub(
+                r'([,\{])(\s*)([\w]+_[\w_]+)(\s*):',
+                r'\1\2"\3"\4:',
+                scripts
+            )
+            for k, v in json.loads(fixed_scripts).items():
+                yield script_url(k, f"{v}a")
+        except Exception:
+            raise Exception("Failed to parse scripts") from e
 
 
 # MARK: XClientTxId parsing

--- a/twscrape/xclid.py
+++ b/twscrape/xclid.py
@@ -56,7 +56,7 @@ def get_scripts_list(text: str):
         # Twitter started returning malformed JSON with unquoted keys
         try:
             fixed_scripts = re.sub(
-                r'([,\{])(\s*)([\w]+_[\w_]+)(\s*):',
+                r'([,\{])(\s*)([\w$]+)(\s*):(?=\s*")',
                 r'\1\2"\3"\4:',
                 scripts
             )


### PR DESCRIPTION
Fixes JSONDecodeError when Twitter returns malformed JSON with unquoted keys. This patch uses regex to handle these unquoted keys before parsing.

Added new test for this behavior.

Addresses #284 

