### PR TITLE
Properly close HTTP client in xclid, fix warning

### DIFF
--- a/twscrape/xclid.py
+++ b/twscrape/xclid.py
@@ -16,8 +16,7 @@ def _make_client() -> httpx.AsyncClient:
     return httpx.AsyncClient(headers=headers, follow_redirects=True)
 
 
-async def get_tw_page_text(url: str, clt: httpx.AsyncClient | None = None):
-    clt = clt or _make_client()
+async def get_tw_page_text(url: str, clt: httpx.AsyncClient):
     rep = await clt.get(url)
 
     rep.raise_for_status()
@@ -198,13 +197,13 @@ def parse_vk_bytes(soup: bs4.BeautifulSoup) -> list[int]:
     return list(base64.b64decode(bytes(el, "utf-8")))
 
 
-async def parse_anim_idx(text: str) -> list[int]:
+async def parse_anim_idx(text: str, clt: httpx.AsyncClient) -> list[int]:
     scripts = list(get_scripts_list(text))
     scripts = [x for x in scripts if "/ondemand.s." in x]
     if not scripts:
         raise Exception("Couldn't get XClientTxId scripts")
 
-    text = await get_tw_page_text(scripts[0])
+    text = await get_tw_page_text(scripts[0], clt)
 
     items = [int(x.group(2)) for x in INDICES_REGEX.finditer(text)]
     if not items:
@@ -226,8 +225,8 @@ def parse_anim_arr(soup: bs4.BeautifulSoup, vk_bytes: list[int]) -> list[list[fl
     return arr
 
 
-async def load_keys(soup: bs4.BeautifulSoup) -> tuple[list[int], str]:
-    anim_idx = await parse_anim_idx(str(soup))
+async def load_keys(soup: bs4.BeautifulSoup, clt: httpx.AsyncClient) -> tuple[list[int], str]:
+    anim_idx = await parse_anim_idx(str(soup), clt)
     vk_bytes = parse_vk_bytes(soup)
     anim_arr = parse_anim_arr(soup, vk_bytes)
 
@@ -245,13 +244,15 @@ async def load_keys(soup: bs4.BeautifulSoup) -> tuple[list[int], str]:
 
 class XClIdGen:
     @staticmethod
-    async def create(clt: httpx.AsyncClient | None = None) -> "XClIdGen":
-        text = await get_tw_page_text("https://x.com/tesla", clt=clt)
-        soup = bs4.BeautifulSoup(text, "html.parser")
-
-        vk_bytes, anim_key = await load_keys(soup)
-        clid_gen = XClIdGen(vk_bytes, anim_key)
-        return clid_gen
+    async def create() -> "XClIdGen":
+        clt = _make_client()
+        try:
+            text = await get_tw_page_text("https://x.com/tesla", clt)
+            soup = bs4.BeautifulSoup(text, "html.parser")
+            vk_bytes, anim_key = await load_keys(soup, clt)
+            return XClIdGen(vk_bytes, anim_key)
+        finally:
+            await clt.aclose()
 
     def __init__(self, vk_bytes: list[int], anim_key: str):
         self.vk_bytes = vk_bytes
@@ -276,10 +277,13 @@ class XClIdGen:
 
 
 async def main():
-    text = await get_tw_page_text("https://x.com/elonmusk")
-    soup = bs4.BeautifulSoup(text, "html.parser")
-
-    vk_bytes, anim_key = await load_keys(soup)
+    clt = _make_client()
+    try:
+        text = await get_tw_page_text("https://x.com/elonmusk", clt)
+        soup = bs4.BeautifulSoup(text, "html.parser")
+        vk_bytes, anim_key = await load_keys(soup, clt)
+    finally:
+        await clt.aclose()
     clid_gen = XClIdGen(vk_bytes, anim_key)
 
     method = "GET"


### PR DESCRIPTION
I had this warning:
```
/usr/local/lib/python3.12/asyncio/selector_events.py:879: ResourceWarning: unclosed transport <_SelectorSocketTransport fd=6 read=idle write=<idle, bufsize=0>>
  _warn(f"unclosed transport {self!r}", ResourceWarning, source=self)
ResourceWarning: Enable tracemalloc to get the object allocation traceback
/usr/local/lib/python3.12/linecache.py:75: ResourceWarning: unclosed <socket.socket fd=6, family=2, type=1, proto=6, laddr=('172.19.0.2', 52420), raddr=('104.18.39.59', 443)>
  stat = os.stat(fullname)
ResourceWarning: Enable tracemalloc to get the object allocation traceback
```

So here is a fix to properly close the client.