### PR TITLE
fix: restore scraping after X 2026-05 changes (issue #306)

### DIFF
--- a/twscrape/api.py
+++ b/twscrape/api.py
@@ -10,21 +10,22 @@ from .queue_client import QueueClient
 from .utils import encode_params, find_obj, get_by_path
 
 # OP_{NAME} – {NAME} should be same as second part of GQL ID (required to auto-update script)
-OP_SearchTimeline = "AIdc203rPpK_k_2KWSdm7g/SearchTimeline"
-OP_UserByRestId = "WJ7rCtezBVT6nk6VM5R8Bw/UserByRestId"
-OP_UserByScreenName = "1VOOyvKkiI3FMmkeDNxM9A/UserByScreenName"
-OP_TweetDetail = "_8aYOgEDz35BrBcBal1-_w/TweetDetail"
-OP_Followers = "Elc_-qTARceHpztqhI9PQA/Followers"
-OP_Following = "C1qZ6bs-L3oc_TKSZyxkXQ/Following"
+# Updated 2026-05-10 (issue #306): old IDs started returning 404.
+OP_SearchTimeline = "AwDeXt15G08TTkW198-eUA/SearchTimeline"
+OP_UserByRestId = "VQfQ9wwYdk6j_u2O4vt64Q/UserByRestId"
+OP_UserByScreenName = "IGgvgiOx4QZndDHuD3x9TQ/UserByScreenName"
+OP_TweetDetail = "_i0BBmP_dK_ZLFa2Y-ei9Q/TweetDetail"
+OP_Followers = "EIcD9sh3tSzxPgvVCU3ebw/Followers"
+OP_Following = "8-yNqgAGituOpu_D5wQb0g/Following"
 OP_Retweeters = "i-CI8t2pJD15euZJErEDrg/Retweeters"
-OP_UserTweets = "HeWHY26ItCfUmm1e6ITjeA/UserTweets"
-OP_UserTweetsAndReplies = "OAx9yEcW3JA9bPo63pcYlA/UserTweetsAndReplies"
-OP_ListLatestTweetsTimeline = "BkauSnPUDQTeeJsxq17opA/ListLatestTweetsTimeline"
-OP_BlueVerifiedFollowers = "ZpmVpf_fBIUgdPErpq2wWg/BlueVerifiedFollowers"
-OP_UserCreatorSubscriptions = "7qcGrVKpcooih_VvJLA1ng/UserCreatorSubscriptions"
-OP_UserMedia = "vFPc2LVIu7so2uA_gHQAdg/UserMedia"
+OP_UserTweets = "lrMzG9qPQHpqJdP3AbM-bQ/UserTweets"
+OP_UserTweetsAndReplies = "3YJONShMAajim63A8iF-sw/UserTweetsAndReplies"
+OP_ListLatestTweetsTimeline = "us9jUxCKI9355JaG6q7sVw/ListLatestTweetsTimeline"
+OP_BlueVerifiedFollowers = "mtFzhZWVIMar04RMPbXn0Q/BlueVerifiedFollowers"
+OP_UserCreatorSubscriptions = "zeEJ3MaWVmy_4m8uyPPijg/UserCreatorSubscriptions"
+OP_UserMedia = "grLxZULbmdPQ7LlCKtG_jQ/UserMedia"
 OP_Bookmarks = "-LGfdImKeQz0xS_jjUwzlA/Bookmarks"
-OP_GenericTimelineById = "CT0YFEFf5GOYa5DJcxM91w/GenericTimelineById"
+OP_GenericTimelineById = "IEvM-wlV9dG9bH1CppaUcg/GenericTimelineById"
 
 GQL_URL = "https://x.com/i/api/graphql"
 GQL_FEATURES = {  # search values here (view source) https://x.com/

--- a/twscrape/utils.py
+++ b/twscrape/utils.py
@@ -124,19 +124,109 @@ def get_typed_object(obj: dict, res: defaultdict[str, list]):
     return res
 
 
+def _merge_legacy(base: dict, legacy) -> dict:
+    # top-level wins, missing keys filled from legacy if it is a dict
+    out = dict(base)
+    if isinstance(legacy, dict):
+        for k, v in legacy.items():
+            out.setdefault(k, v)
+    return out
+
+
+def _flatten_user_v2(obj: dict) -> dict:
+    flat = _merge_legacy(obj, obj.get("legacy"))
+    rest_id = obj.get("rest_id") or flat.get("rest_id") or flat.get("id_str")
+    flat["rest_id"] = rest_id
+    flat["id_str"] = str(rest_id) if rest_id is not None else flat.get("id_str", "")
+    flat["id"] = int(rest_id) if rest_id is not None and str(rest_id).isdigit() else 0
+    flat["legacy"] = None
+
+    core = obj.get("core") or {}
+    if isinstance(core, dict):
+        for k in ("screen_name", "name", "created_at"):
+            if k not in flat and k in core:
+                flat[k] = core[k]
+
+    if "profile_image_url_https" not in flat:
+        avatar_url = (obj.get("avatar") or {}).get("image_url")
+        if avatar_url:
+            flat["profile_image_url_https"] = avatar_url
+
+    if not isinstance(flat.get("location"), str):
+        loc = (obj.get("location") or {}).get("location")
+        if loc is not None:
+            flat["location"] = loc
+
+    if "protected" not in flat:
+        prot = (obj.get("privacy") or {}).get("protected")
+        if prot is not None:
+            flat["protected"] = prot
+
+    if "verified" not in flat:
+        ver = (obj.get("verification") or {}).get("verified")
+        if ver is not None:
+            flat["verified"] = ver
+
+    if "is_blue_verified" not in flat and "is_blue_verified" in obj:
+        flat["is_blue_verified"] = obj["is_blue_verified"]
+
+    if not flat.get("description"):
+        bio = (obj.get("profile_bio") or {}).get("description")
+        if bio is not None:
+            flat["description"] = bio
+
+    flat.setdefault("description", "")
+    flat.setdefault("location", "")
+    flat.setdefault("followers_count", 0)
+    flat.setdefault("friends_count", 0)
+    flat.setdefault("statuses_count", 0)
+    flat.setdefault("favourites_count", 0)
+    flat.setdefault("listed_count", 0)
+    flat.setdefault("media_count", 0)
+    flat.setdefault("profile_image_url_https", "")
+    flat.setdefault("entities", {})
+    flat.setdefault("pinned_tweet_ids_str", [])
+    return flat
+
+
+def _flatten_tweet_v2(obj: dict) -> dict:
+    flat = _merge_legacy(obj, obj.get("legacy"))
+    rest_id = obj.get("rest_id") or flat.get("rest_id") or flat.get("id_str")
+    flat["rest_id"] = rest_id
+    flat["id_str"] = str(rest_id) if rest_id is not None else flat.get("id_str", "")
+    flat["id"] = int(rest_id) if rest_id is not None and str(rest_id).isdigit() else 0
+    flat["legacy"] = None
+    if "source" not in flat and "source" in obj:
+        flat["source"] = obj["source"]
+    flat.setdefault("full_text", "")
+    flat.setdefault("lang", "")
+    flat.setdefault("reply_count", 0)
+    flat.setdefault("retweet_count", 0)
+    flat.setdefault("favorite_count", 0)
+    flat.setdefault("quote_count", 0)
+    flat.setdefault("bookmark_count", 0)
+    flat.setdefault("entities", {})
+    flat.setdefault("conversation_id_str", flat["id_str"])
+    return flat
+
+
 def to_old_obj(obj: dict):
-    return {
-        **obj,
-        **obj["legacy"],
-        "id_str": str(obj["rest_id"]),
-        "id": int(obj["rest_id"]),
-        "legacy": None,
-    }
+    # Since 2026-05 X serves Tweet/User with legacy=null. Tweet fields moved
+    # to the top level; User fields are split between top-level and the
+    # sub-objects core/avatar/location/privacy/verification/profile_bio.
+    # Always rebuild a flat dict; works on the old schema too.
+    if not isinstance(obj, dict):
+        return obj
+    if obj.get("__typename") == "User":
+        return _flatten_user_v2(obj)
+    return _flatten_tweet_v2(obj)
 
 
 def to_old_rep(obj: dict) -> dict[str, dict]:
     tmp = get_typed_object(obj, defaultdict(list))
 
+    # "legacy" in x still matches under the new schema: the key is present
+    # with value None, so membership tests keep working.
     tw1 = [x for x in tmp.get("Tweet", []) if "legacy" in x]
     tw1 = {str(x["rest_id"]): to_old_obj(x) for x in tw1}
 

--- a/twscrape/xclid.py
+++ b/twscrape/xclid.py
@@ -246,6 +246,15 @@ async def load_keys(soup: bs4.BeautifulSoup) -> tuple[list[int], str]:
 class XClIdGen:
     @staticmethod
     async def create(clt: httpx.AsyncClient | None = None) -> "XClIdGen":
+        # issue #306: since 2026-04 the bundle no longer contains the
+        # e=>e+"."+ script-list pattern, so get_scripts_list() fails.
+        # Use the upstream XClientTransaction lib when available; fall back
+        # to the native implementation otherwise.
+        try:
+            return await _XClIdGenExternal.create(clt)
+        except ImportError:
+            pass
+
         text = await get_tw_page_text("https://x.com/tesla", clt=clt)
         soup = bs4.BeautifulSoup(text, "html.parser")
 
@@ -270,6 +279,36 @@ class XClIdGen:
         pld = bytearray([num, *[x ^ num for x in pld]])
         out = base64.b64encode(pld).decode("utf-8").strip("=")
         return out
+
+
+class _XClIdGenExternal:
+    # Adapter over the optional XClientTransaction PyPI package.
+    # Install with: pip install XClientTransaction
+    # The lib is sync (uses requests), so the bootstrap runs in a thread.
+
+    def __init__(self, ct):
+        self._ct = ct
+
+    def calc(self, method: str, path: str) -> str:
+        return self._ct.generate_transaction_id(method=method, path=path)
+
+    @staticmethod
+    async def create(clt: httpx.AsyncClient | None = None) -> "_XClIdGenExternal":
+        import asyncio
+        return await asyncio.to_thread(_XClIdGenExternal._create_sync)
+
+    @staticmethod
+    def _create_sync() -> "_XClIdGenExternal":
+        import requests
+        from x_client_transaction import ClientTransaction
+        from x_client_transaction.utils import get_ondemand_file_url, handle_x_migration
+
+        sess = requests.Session()
+        sess.headers["User-Agent"] = UserAgent().chrome
+        home = handle_x_migration(sess)
+        ondemand = sess.get(get_ondemand_file_url(response=home), timeout=30)
+        ct = ClientTransaction(home_page_response=home, ondemand_file_response=ondemand)
+        return _XClIdGenExternal(ct)
 
 
 # MARK: Demo code


### PR DESCRIPTION
Closes #306.

Three independent fixes, one per commit so they can be cherry-picked:

1. **api.py**: refresh 13 GraphQL queryIds (old ones return 404).
2. **xclid.py**: optional fallback to the `XClientTransaction` PyPI
   package, since the bundle no longer exposes the script-list pattern
   used by `get_scripts_list()`. Native code path preserved.
3. **utils.py**: flatten Tweet/User from the new schema where
   `legacy` is `null` and fields are split between top-level and the
   `core` / `avatar` / `location` / `privacy` / `verification` /
   `profile_bio` sub-objects. Backward compatible.

Verified end-to-end: `api.search('python lang:en', limit=2)` returns
24 parsed tweets with full text/user/dates.

To enable the xclid fallback: `pip install XClientTransaction`.