### PR TITLE
feat: optional bounded wait for locked accounts in get_for_queue_or_wait

### DIFF
--- a/tests/test_pool.py
+++ b/tests/test_pool.py
@@ -1,6 +1,7 @@
 import pytest
 
 from twscrape.accounts_pool import AccountsPool, NoAccountError
+from twscrape.api import API
 from twscrape.utils import utc
 
 
@@ -238,6 +239,60 @@ async def test_get_for_queue_or_wait_raises_via_env(pool_mock: AccountsPool, mon
     monkeypatch.setenv("TWS_RAISE_WHEN_NO_ACCOUNT", "1")
     with pytest.raises(NoAccountError):
         await pool_mock.get_for_queue_or_wait("TestQueue")
+
+
+async def test_get_for_queue_or_wait_waits_for_locked_account(
+    pool_mock: AccountsPool, monkeypatch
+):
+    queue = "TestQueue"
+    pool = AccountsPool(pool_mock._db_file, wait_timeout=1, wait_interval=0.1)
+    await pool.add_account("user1", "pass1", "email1", "ep1")
+    await pool.set_active("user1", True)
+    await pool.get_for_queue(queue)
+
+    intervals = []
+
+    async def release_account(interval):
+        intervals.append(interval)
+        await pool.unlock("user1", queue)
+
+    monkeypatch.setattr("twscrape.accounts_pool.asyncio.sleep", release_account)
+
+    account = await pool.get_for_queue_or_wait(queue)
+
+    assert account is not None
+    assert account.username == "user1"
+    assert intervals == [0.1]
+
+
+async def test_get_for_queue_or_wait_returns_none_when_timeout_is_zero(pool_mock: AccountsPool):
+    queue = "TestQueue"
+    pool = AccountsPool(pool_mock._db_file, wait_timeout=0)
+    await pool.add_account("user1", "pass1", "email1", "ep1")
+    await pool.set_active("user1", True)
+    await pool.get_for_queue(queue)
+
+    assert await pool.get_for_queue_or_wait(queue) is None
+
+
+async def test_get_for_queue_or_wait_does_not_wait_without_active_accounts(
+    pool_mock: AccountsPool, monkeypatch
+):
+    pool = AccountsPool(pool_mock._db_file, wait_timeout=1)
+
+    async def fail_if_called(_):
+        pytest.fail("should not wait when no accounts are active")
+
+    monkeypatch.setattr("twscrape.accounts_pool.asyncio.sleep", fail_if_called)
+
+    assert await pool.get_for_queue_or_wait("TestQueue") is None
+
+
+def test_api_passes_wait_config_to_new_pool(tmp_path):
+    api = API(str(tmp_path / "test.db"), wait_timeout=1, wait_interval=0.1)
+
+    assert api.pool._wait_timeout == 1
+    assert api.pool._wait_interval == 0.1
 
 
 async def test_accounts_info_active_first(pool_mock: AccountsPool):

--- a/twscrape/accounts_pool.py
+++ b/twscrape/accounts_pool.py
@@ -39,10 +39,20 @@ class AccountsPool:
         db_file="accounts.db",
         login_config: LoginConfig | None = None,
         raise_when_no_account=False,
+        wait_timeout: float | None = None,
+        wait_interval: float = 5.0,
     ):
         self._db_file = db_file
         self._login_config = login_config or LoginConfig()
         self._raise_when_no_account = raise_when_no_account
+        # When every active account is momentarily locked (in-use or rate-limited),
+        # get_for_queue_or_wait polls for up to wait_timeout seconds (every
+        # wait_interval) before giving up. This lets a brief in-use lock resolve into
+        # a successful acquisition instead of an instant failure, while a real
+        # rate-limit is not waited out indefinitely. None keeps the legacy behaviour
+        # (raise immediately if raise_when_no_account, otherwise block forever).
+        self._wait_timeout = wait_timeout
+        self._wait_interval = wait_interval
 
     async def load_from_file(self, filepath: str, line_format: str):
         line_delim = guess_delim(line_format)
@@ -292,30 +302,43 @@ class AccountsPool:
         return await self._get_and_lock(queue, q)
 
     async def get_for_queue_or_wait(self, queue: str) -> Account | None:
+        start = utc.now()
         msg_shown = False
         while True:
             account = await self.get_for_queue(queue)
-            if not account:
-                if self._raise_when_no_account or get_env_bool("TWS_RAISE_WHEN_NO_ACCOUNT"):
-                    raise NoAccountError(f"No account available for queue {queue}")
-
-                if not msg_shown:
-                    nat = await self.next_available_at(queue)
-                    if not nat:
-                        logger.warning("No active accounts. Stopping...")
-                        return None
-
-                    msg = f'No account available for queue "{queue}". Next available at {nat}'
-                    logger.info(msg)
-                    msg_shown = True
-
-                await asyncio.sleep(5)
-                continue
-            else:
+            if account is not None:
                 if msg_shown:
                     logger.info(f"Continuing with account {account.username} on queue {queue}")
+                return account
 
-            return account
+            raise_no_account = self._raise_when_no_account or get_env_bool("TWS_RAISE_WHEN_NO_ACCOUNT")
+
+            # next_available_at returns None only when no active account exists at all,
+            # in which case waiting is futile. A timestamp means active accounts exist
+            # but are all locked right now (in-use or rate-limited).
+            nat = await self.next_available_at(queue)
+            no_active = not nat
+
+            # Give up (raise / stop) when: no active account exists, the caller opted
+            # out of waiting (wait_timeout is None), or the wait budget is exhausted.
+            elapsed = (utc.now() - start).total_seconds()
+            give_up = no_active or self._wait_timeout is None or elapsed >= self._wait_timeout
+            if give_up:
+                if raise_no_account:
+                    raise NoAccountError(f"No account available for queue {queue}")
+                if no_active:
+                    logger.warning("No active accounts. Stopping...")
+                    return None
+                if self._wait_timeout is not None:
+                    return None
+                # wait_timeout is None and not raising: fall through to the legacy
+                # unbounded wait below.
+
+            if not msg_shown:
+                logger.info(f'No account available for queue "{queue}". Next available at {nat}')
+                msg_shown = True
+
+            await asyncio.sleep(self._wait_interval)
 
     async def next_available_at(self, queue: str):
         qs = f"""

--- a/twscrape/accounts_pool.py
+++ b/twscrape/accounts_pool.py
@@ -311,7 +311,9 @@ class AccountsPool:
                     logger.info(f"Continuing with account {account.username} on queue {queue}")
                 return account
 
-            raise_no_account = self._raise_when_no_account or get_env_bool("TWS_RAISE_WHEN_NO_ACCOUNT")
+            raise_no_account = self._raise_when_no_account or get_env_bool(
+                "TWS_RAISE_WHEN_NO_ACCOUNT"
+            )
 
             # next_available_at returns None only when no active account exists at all,
             # in which case waiting is futile. A timestamp means active accounts exist

--- a/twscrape/api.py
+++ b/twscrape/api.py
@@ -106,13 +106,20 @@ class API:
         debug=False,
         proxy: str | None = None,
         raise_when_no_account=False,
+        wait_timeout: float | None = None,
+        wait_interval: float = 5.0,
     ):
+        pool_kwargs = {
+            "raise_when_no_account": raise_when_no_account,
+            "wait_timeout": wait_timeout,
+            "wait_interval": wait_interval,
+        }
         if isinstance(pool, AccountsPool):
             self.pool = pool
         elif isinstance(pool, str):
-            self.pool = AccountsPool(db_file=pool, raise_when_no_account=raise_when_no_account)
+            self.pool = AccountsPool(db_file=pool, **pool_kwargs)
         else:
-            self.pool = AccountsPool(raise_when_no_account=raise_when_no_account)
+            self.pool = AccountsPool(**pool_kwargs)
 
         self.proxy = proxy
         self.debug = debug

--- a/twscrape/api.py
+++ b/twscrape/api.py
@@ -109,17 +109,21 @@ class API:
         wait_timeout: float | None = None,
         wait_interval: float = 5.0,
     ):
-        pool_kwargs = {
-            "raise_when_no_account": raise_when_no_account,
-            "wait_timeout": wait_timeout,
-            "wait_interval": wait_interval,
-        }
         if isinstance(pool, AccountsPool):
             self.pool = pool
         elif isinstance(pool, str):
-            self.pool = AccountsPool(db_file=pool, **pool_kwargs)
+            self.pool = AccountsPool(
+                db_file=pool,
+                raise_when_no_account=raise_when_no_account,
+                wait_timeout=wait_timeout,
+                wait_interval=wait_interval,
+            )
         else:
-            self.pool = AccountsPool(**pool_kwargs)
+            self.pool = AccountsPool(
+                raise_when_no_account=raise_when_no_account,
+                wait_timeout=wait_timeout,
+                wait_interval=wait_interval,
+            )
 
         self.proxy = proxy
         self.debug = debug


### PR DESCRIPTION
### Problem

`AccountsPool.get_for_queue_or_wait` currently offers only two behaviours when
no account can be acquired:

- `raise_when_no_account=True` → raise `NoAccountError` immediately;
- otherwise → poll every 5s and block **forever**.

Under concurrency this is awkward. If a pool has fewer accounts than concurrent
requests, a request often finds every account *active but momentarily locked*
by another in-flight request. Raising immediately makes that transient in-use
lock indistinguishable from a real rate-limit, so callers report spurious
failures; blocking forever, conversely, is undesirable when the pool is
genuinely exhausted. There's no middle ground of "wait a little for a busy
account to free."

### Change

Add two optional knobs, threaded through `API` → `AccountsPool`:

- `wait_timeout: float | None = None` — when accounts are active but all locked,
  poll for up to this many seconds before giving up.
- `wait_interval: float = 5.0` — poll cadence (was hard-coded to 5).

`get_for_queue_or_wait` now distinguishes the two "no account" situations via
`next_available_at`:

- **No active account** → waiting can't help → return/raise immediately (as
  before).
- **Active accounts, all locked** → wait up to `wait_timeout`; a lock that frees
  in time yields a normal acquisition, otherwise give up.

### Compatibility

`wait_timeout` defaults to `None`, preserving the current behaviour exactly
(immediate raise with `raise_when_no_account`, otherwise unbounded wait).
Existing tests pass unchanged.