### PR TITLE
fix: use account cookies for XClId asset requests

### DIFF
--- a/tests/test_queue_client.py
+++ b/tests/test_queue_client.py
@@ -2,9 +2,10 @@ from contextlib import aclosing
 
 import pytest
 
+from twscrape.account import Account
 from twscrape.accounts_pool import AccountsPool
 from twscrape.http import ConnectError, NetworkError
-from twscrape.queue_client import QueueClient
+from twscrape.queue_client import QueueClient, XClIdGenStore
 from twscrape.utils import utc
 
 from .mock_http import MockClient
@@ -452,5 +453,47 @@ async def test_404_retries_exhaust_and_abort(client_fixture: CF):
     with patch("twscrape.queue_client.asyncio.sleep"):
         rep = await client.get(URL)
     assert rep is None
+
+    await client.__aexit__(None, None, None)
+
+
+async def test_queue_client_passes_account_cookies_to_xclid(pool_mock: AccountsPool, monkeypatch):
+    mock = MockClient()
+    seen = {}
+
+    class FakeXClIdGen:
+        def calc(self, *args, **kwargs):
+            return "mocked-clid"
+
+    async def fake_get(cls, username, cookies=None, fresh=False):
+        seen["username"] = username
+        seen["cookies"] = cookies
+        seen["fresh"] = fresh
+        return FakeXClIdGen()
+
+    monkeypatch.setattr(Account, "make_client", lambda self, proxy=None: mock)
+    monkeypatch.setattr(XClIdGenStore, "get", classmethod(fake_get))
+
+    await pool_mock.add_account(
+        "user1",
+        "pass1",
+        "email1",
+        "email_pass1",
+        cookies='{"auth_token": "abc", "ct0": "def"}',
+    )
+    await pool_mock.set_active("user1", True)
+
+    client = QueueClient(pool_mock, "SearchTimeline")
+    await client.__aenter__()
+
+    mock.add_response(json={"ok": True})
+    rep = await client.get(URL)
+
+    assert rep is not None
+    assert seen == {
+        "username": "user1",
+        "cookies": {"auth_token": "abc", "ct0": "def"},
+        "fresh": False,
+    }
 
     await client.__aexit__(None, None, None)

--- a/tests/test_xclid.py
+++ b/tests/test_xclid.py
@@ -1,0 +1,66 @@
+import twscrape.xclid as xclid
+
+
+class FakeClient:
+    def __init__(self):
+        self.closed = False
+
+    async def aclose(self):
+        self.closed = True
+
+
+async def test_xclid_create_passes_cookies_to_client(monkeypatch):
+    seen = {}
+    fake_client = FakeClient()
+
+    def fake_make_client(*, headers=None, cookies=None):
+        seen["headers"] = headers
+        seen["cookies"] = cookies
+        return fake_client
+
+    async def fake_get_tw_page_text(url, clt):
+        seen["url"] = url
+        seen["client"] = clt
+        return "<html></html>"
+
+    async def fake_load_keys(soup, clt):
+        seen["load_client"] = clt
+        return [1, 2, 3], "anim-key"
+
+    monkeypatch.setattr(xclid, "_make_http_client", fake_make_client)
+    monkeypatch.setattr(xclid, "get_tw_page_text", fake_get_tw_page_text)
+    monkeypatch.setattr(xclid, "load_keys", fake_load_keys)
+
+    cookies = {"auth_token": "abc", "ct0": "def"}
+    gen = await xclid.XClIdGen.create(cookies=cookies)
+
+    assert gen.vk_bytes == [1, 2, 3]
+    assert gen.anim_key == "anim-key"
+    assert seen["headers"] == {"user-agent": "@chrome"}
+    assert seen["cookies"] == cookies
+    assert seen["url"] == "https://x.com/tesla"
+    assert seen["client"] is fake_client
+    assert seen["load_client"] is fake_client
+    assert fake_client.closed is True
+
+
+async def test_xclid_create_without_cookies(monkeypatch):
+    seen = {}
+    fake_client = FakeClient()
+
+    def fake_make_client(*, headers=None, cookies=None):
+        seen["cookies"] = cookies
+        return fake_client
+
+    async def fake_get_tw_page_text(url, clt):
+        return "<html></html>"
+
+    async def fake_load_keys(soup, clt):
+        return [1, 2, 3], "anim-key"
+
+    monkeypatch.setattr(xclid, "_make_http_client", fake_make_client)
+    monkeypatch.setattr(xclid, "get_tw_page_text", fake_get_tw_page_text)
+    monkeypatch.setattr(xclid, "load_keys", fake_load_keys)
+
+    await xclid.XClIdGen.create()
+    assert seen["cookies"] is None

--- a/twscrape/queue_client.py
+++ b/twscrape/queue_client.py
@@ -25,14 +25,14 @@ class XClIdGenStore:
     items: dict[str, XClIdGen] = {}  # username -> XClIdGen
 
     @classmethod
-    async def get(cls, username: str, fresh=False) -> XClIdGen:
+    async def get(cls, username: str, cookies: dict[str, str] | None = None, fresh=False) -> XClIdGen:
         if username in cls.items and not fresh:
             return cls.items[username]
 
         tries = 0
         while tries < 3:
             try:
-                clid_gen = await XClIdGen.create()
+                clid_gen = await XClIdGen.create(cookies=cookies)
                 cls.items[username] = clid_gen
                 return clid_gen
             except Exception as e:
@@ -63,7 +63,7 @@ class Ctx:
 
         tries = 0
         while tries < 3:
-            gen = await XClIdGenStore.get(self.acc.username, fresh=tries > 0)
+            gen = await XClIdGenStore.get(self.acc.username, cookies=self.acc.cookies, fresh=tries > 0)
             hdr = {"x-client-transaction-id": gen.calc(method, path)}
             rep = await self.clt.request(method, url, params=params, headers=hdr)
             if rep.status_code != 404:

--- a/twscrape/xclid.py
+++ b/twscrape/xclid.py
@@ -13,8 +13,8 @@ from .http import HttpClient
 from .http import make_client as _make_http_client
 
 
-def _make_client() -> HttpClient:
-    return _make_http_client(headers={"user-agent": "@chrome"})
+def _make_client(cookies: dict[str, str] | None = None) -> HttpClient:
+    return _make_http_client(headers={"user-agent": "@chrome"}, cookies=cookies)
 
 
 async def get_tw_page_text(url: str, clt: HttpClient):
@@ -315,8 +315,11 @@ async def load_keys(soup: bs4.BeautifulSoup, clt: HttpClient) -> tuple[list[int]
 
 class XClIdGen:
     @staticmethod
-    async def create() -> "XClIdGen":
-        clt = _make_client()
+    async def create(cookies: dict[str, str] | None = None) -> "XClIdGen":
+        # X serves a different/legacy web build to authenticated vs anonymous
+        # sessions. Only authenticated sessions reliably contain the indices
+        # this parser depends on (see INDICES_FILE_RE).
+        clt = _make_client(cookies=cookies)
         try:
             text = await get_tw_page_text("https://x.com/tesla", clt)
             soup = bs4.BeautifulSoup(text, "html.parser")

--- a/twscrape/xclid.py
+++ b/twscrape/xclid.py
@@ -2,8 +2,10 @@ import asyncio
 import base64
 import hashlib
 import math
+import os
 import random
 import re
+import sys
 import time
 from urllib.parse import urljoin
 
@@ -11,6 +13,7 @@ import bs4
 
 from .http import HttpClient
 from .http import make_client as _make_http_client
+from .utils import parse_cookies
 
 
 def _make_client(cookies: dict[str, str] | None = None) -> HttpClient:
@@ -351,7 +354,12 @@ class XClIdGen:
 
 
 async def main():
-    clt = _make_client()
+    cookies_raw = os.getenv("TWS_COOKIES")
+    cookies = parse_cookies(cookies_raw) if cookies_raw else None
+    if not cookies:
+        print("Warning: TWS_COOKIES not set — anonymous fetch will likely fail.", file=sys.stderr)
+
+    clt = _make_client(cookies=cookies)
     try:
         text = await get_tw_page_text("https://x.com/elonmusk", clt)
         soup = bs4.BeautifulSoup(text, "html.parser")


### PR DESCRIPTION
## Summary

Fixes issue #320 that was causing the following error:
```
WARNING  | twscrape.queue_client:get:40 - XClIdGen creation attempt 1/3 failed: Exception: Couldn't get XClientTxId indices script
```

## Changes

- Modify `XClIdGen.create()` and `XClIdGenStore.get()` to use cookies so they fetch from authenticated sessions.
- Update `main()` demo to accept cookies and fail gracefully via warning if unset.

## Tests
- Add cookie test coverage for both `XClIdGen.create()` and `XClIdGenStore.get()` in `tests/test_xclid.py` and `tests/test_queue_client.py` respectively.