### PR TITLE
fix: Accept 16-hex chunk hashes in legacy webpack build, fixes #327

### DIFF
--- a/tests/test_xclid.py
+++ b/tests/test_xclid.py
@@ -117,6 +117,32 @@ def test_logged_out_entry_is_account_error():
         xclid.get_scripts_list(html)
 
 
+# In the legacy webpack fixtures the name map comes BEFORE the hash map: hash values
+# must be excluded from the name map by format alone, or they overwrite the names.
+def test_legacy_webpack_build_with_7_hex_hashes():
+    html = '{100:"main",200:"shared~feature"}+{100:"a1b2c3d",200:"0badca4"}'
+
+    urls = xclid.get_scripts_list(html)
+
+    assert urls == [
+        "https://abs.twimg.com/responsive-web/client-web/main.a1b2c3da.js",
+        "https://abs.twimg.com/responsive-web/client-web/shared~feature.0badca4a.js",
+    ]
+
+
+def test_legacy_webpack_build_with_16_hex_hashes():
+    # Hash format served since 2026-08-24, e.g. main.15e48250ae23af9ea.js
+    # https://github.com/vladkens/twscrape/issues/327
+    html = '{100:"main",200:"shared~feature"}+{100:"15e48250ae23af9e",200:"00c0ffee00c0ffee"}'
+
+    urls = xclid.get_scripts_list(html)
+
+    assert urls == [
+        "https://abs.twimg.com/responsive-web/client-web/main.15e48250ae23af9ea.js",
+        "https://abs.twimg.com/responsive-web/client-web/shared~feature.00c0ffee00c0ffeea.js",
+    ]
+
+
 async def test_find_indices_url_complete_scan_is_parse_error():
     client = MockClient()
     client.add_response(text="no reference")

--- a/twscrape/xclid.py
+++ b/twscrape/xclid.py
@@ -73,7 +73,7 @@ def get_scripts_list(text: str) -> list[str]:
     so we just collect those URLs. If none are found we fall back to the legacy
     webpack build, which embeds two maps in the page and requires URL
     reconstruction:
-      - Hash map  {chunk_id: "7hexchars"}            values are exactly 7 lowercase hex digits
+      - Hash map  {chunk_id: "hexchars"}             values are exactly 7 or 16 lowercase hex digits
       - Name map  {chunk_id: "human_readable_name"}  values contain non-hex characters
       URL format: https://abs.twimg.com/responsive-web/client-web/{name}.{hash}a.js
     """
@@ -84,17 +84,20 @@ def get_scripts_list(text: str) -> list[str]:
         return urls
 
     # Legacy webpack build fallback.
-    # Hash map: values are exactly 7 lowercase hex digits (distinguishes them from name-map values)
-    hash_map = {m.group(1): m.group(2) for m in re.finditer(r'(\d+):"([0-9a-f]{7})"', text)}
+    # Hash map: values are exactly 7 or 16 lowercase hex digits (7 before 2026-08-24, 16 since;
+    # distinguishes them from name-map values)
+    hash_map = {
+        m.group(1): m.group(2) for m in re.finditer(r'(\d+):"([0-9a-f]{7}|[0-9a-f]{16})"', text)
+    }
 
     if not hash_map:
         raise XClIdParseError("X web scripts not found")
 
-    # Name map: values that are NOT exactly 7 hex digits (i.e. human-readable chunk names)
+    # Name map: values that are NOT exactly 7 or 16 hex digits (i.e. human-readable chunk names)
     name_map: dict[str, str] = {}
     for m in re.finditer(r'(\d+):"([^"]+)"', text):
         val = m.group(2)
-        if not re.fullmatch(r"[0-9a-f]{7}", val):
+        if not re.fullmatch(r"[0-9a-f]{7}|[0-9a-f]{16}", val):
             name_map[m.group(1)] = val
 
     return [


### PR DESCRIPTION
Fixes #327 