### PR TITLE
feat: restore user_by_id, fixes #326

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -171,6 +171,7 @@ Users and timelines:
 user_login = "xdevelopers"
 user_id = 2244994945
 
+await api.user_by_id(user_id)  # User
 await api.user_by_login(user_login)  # User
 await api.user_about(user_login)  # AccountAbout
 await gather(api.following(user_id, limit=20))  # list[User]
@@ -228,6 +229,7 @@ twscrape tweet_details TWEET_ID
 twscrape tweet_replies TWEET_ID --limit=20
 twscrape tweet_thread TWEET_ID --limit=20
 twscrape retweeters TWEET_ID --limit=20
+twscrape user_by_id USER_ID
 twscrape user_by_login USERNAME
 twscrape user_about USERNAME
 twscrape user_media USER_ID --limit=20

--- a/scripts/update-gql-ops.py
+++ b/scripts/update-gql-ops.py
@@ -24,48 +24,16 @@ import sys
 from urllib.parse import urljoin
 
 from twscrape.http import HttpClient, make_client
-from twscrape.xclid import get_tw_page_text, script_url
+from twscrape.xclid import get_scripts_list, get_tw_page_text
 
 API_FILE = "twscrape/api.py"
 CACHE_DIR = "/tmp/twscrape-ops"
 MARKER = "# GQL_OPS_CODEGEN"
-X_WEB_URL_RE = re.compile(r"https://[\w.-]+/x-web/[\w./-]+\.js")
-RESPONSIVE_WEB_URL_RE = re.compile(r"https://[\w.-]+/responsive-web/client-web/[\w./-]+\.js")
 JS_REF_RE = re.compile(r'(?:from|import)\s*\(?\s*[`"]((?:\.{1,2}/)[^`"]+?\.js)[`"]')
 
 
 def _is_relevant_script(url: str) -> bool:
     return "/i18n/" not in url and "/icons/" not in url and "react-syntax-highlighter" not in url
-
-
-def get_scripts_list(text: str) -> list[str]:
-    urls = list(dict.fromkeys(X_WEB_URL_RE.findall(text) + RESPONSIVE_WEB_URL_RE.findall(text)))
-
-    # HTML can contain both direct script URLs and a legacy webpack chunk map.
-    # The map has separate chunk_id -> name and chunk_id -> hash entries; combine
-    # them into /responsive-web/client-web/{name}.{hash}a.js URLs.
-    hash_map = {m.group(1): m.group(2) for m in re.finditer(r'(\d+):"([0-9a-f]{7})"', text)}
-    if not hash_map and not urls:
-        raise Exception("Failed to parse scripts")
-
-    name_map: dict[str, str] = {}
-    for m in re.finditer(r'(\d+):"([^"]+)"', text):
-        val = m.group(2)
-        if not re.fullmatch(r"[0-9a-f]{7}", val):
-            name_map[m.group(1)] = val
-
-    urls.extend(
-        script_url(name_map.get(chunk_id, chunk_id), hash_val + "a")
-        for chunk_id, hash_val in hash_map.items()
-    )
-    return list(dict.fromkeys(urls))
-
-
-def _get_legacy_main_script(text: str) -> str | None:
-    match = re.search(r"/client-web/main\.([^.\"']+)\.js", text)
-    if not match:
-        return None
-    return script_url("main", match.group(1))
 
 
 async def get_scripts() -> list[tuple[str, str]]:
@@ -76,8 +44,6 @@ async def get_scripts() -> list[tuple[str, str]]:
         for page_url in ("https://x.com/xdevelopers", "https://x.com/home"):
             text = await get_tw_page_text(page_url, clt)
             urls.extend(get_scripts_list(text))
-            if main_script := _get_legacy_main_script(text):
-                urls.append(main_script)
 
     urls = list(dict.fromkeys(urls))
     urls = [x for x in urls if _is_relevant_script(x)]

--- a/scripts/update-mocked-data.py
+++ b/scripts/update-mocked-data.py
@@ -234,6 +234,7 @@ def search_query() -> str:
 
 
 COMMANDS = [
+    ("user_by_id", lambda api: api.user_by_id_raw(_UID)),
     ("user_by_login", lambda api: api.user_by_login_raw("xdevelopers")),
     ("user_about", lambda api: api.user_about_raw("xdevelopers")),
     ("following", lambda api: _first(api.following_raw(_UID, limit=10))),

--- a/tests/mocked-data/__meta.json
+++ b/tests/mocked-data/__meta.json
@@ -63,6 +63,10 @@
     "TzOG2twZEfhr9KmClvVVqA/AboutAccountQuery",
     "e327f458b11eec3ba114417fe90b6812fa8417e2d7d32425adba704a1852ebd9"
   ],
+  "user_by_id": [
+    "xvmVfRLmnr1alc5f2dib0Q/UserByRestId",
+    "d6ba39b362e58f09ef2ca2d1743e2c451ba27dad3b2a799ba1c87639b7db7ffe"
+  ],
   "user_by_login": [
     "Gb-d6r0vxPOADdG62OEBpQ/UserByScreenName",
     "be9dfa1b596b1382ea2bf61c1802972d53ea0e8ddf61cfab93fb79eb471e8040"

--- a/tests/mocked-data/raw_user_by_id.json
+++ b/tests/mocked-data/raw_user_by_id.json
@@ -1,0 +1,136 @@
+{
+  "data": {
+    "user": {
+      "result": {
+        "__typename": "User",
+        "action_counts": {
+          "favorites_count": 2659
+        },
+        "affiliates_highlighted_label": {
+          "label": {
+            "badge": {
+              "url": "https://pbs.twimg.com/profile_images/1955359038532653056/OSHY3ewP_bigger.jpg"
+            },
+            "description": "X",
+            "url": {
+              "url": "https://twitter.com/X",
+              "urlType": "DeepLink"
+            },
+            "userLabelDisplayType": "Badge",
+            "userLabelType": "BusinessLabel"
+          }
+        },
+        "avatar": {
+          "image_url": "https://pbs.twimg.com/profile_images/1683501992314798080/xl1POYLw_normal.jpg"
+        },
+        "banner": {
+          "image_url": "https://pbs.twimg.com/profile_banners/2244994945/1690213128"
+        },
+        "business_account": {},
+        "core": {
+          "created_at": "Sat Dec 14 04:35:55 +0000 2013",
+          "name": "Developers",
+          "screen_name": "XDevelopers"
+        },
+        "creator_subscriptions_count": 0,
+        "dm_permissions": {
+          "can_dm": true
+        },
+        "follow_request_sent": false,
+        "has_graduated_access": true,
+        "has_hidden_subscriptions_on_profile": false,
+        "highlights_info": {
+          "can_highlight_tweets": true,
+          "highlighted_tweets": "4"
+        },
+        "id": "VXNlcjoyMjQ0OTk0OTQ1",
+        "is_blue_verified": true,
+        "location": {
+          "location": "127.0.0.1"
+        },
+        "media_permissions": {
+          "can_media_tag": true
+        },
+        "notifications_settings": {
+          "notifications_enabled": false
+        },
+        "pinned_items": {
+          "tweet_ids_str": [
+            "2019881223666233717"
+          ]
+        },
+        "possibly_sensitive": false,
+        "privacy": {
+          "protected": false
+        },
+        "professional": {
+          "category": [
+            {
+              "icon_name": "IconBriefcaseStroke",
+              "id": 1009,
+              "name": "Community"
+            }
+          ],
+          "professional_type": "Business",
+          "rest_id": "1516891231749517312"
+        },
+        "profile_bio": {
+          "description": "The voice of the X Dev team and your official source for updates, news, and events, related to the X API.",
+          "entities": {
+            "description": {},
+            "url": {
+              "urls": [
+                {
+                  "display_url": "docs.x.com",
+                  "expanded_url": "https://docs.x.com/",
+                  "indices": [
+                    0,
+                    23
+                  ],
+                  "url": "https://t.co/NIwHVIVyrN"
+                }
+              ]
+            }
+          }
+        },
+        "profile_description_language": "en",
+        "profile_image_shape": "Square",
+        "profile_metadata": {
+          "profile_interstitial_type": ""
+        },
+        "profile_sort_enabled": true,
+        "profile_translation": {
+          "translator_type": "regular"
+        },
+        "relationship_counts": {
+          "followers": 697752,
+          "following": 763
+        },
+        "relationship_perspectives": {
+          "blocked_by": false,
+          "blocking": false,
+          "followed_by": false,
+          "following": false,
+          "live_following": false,
+          "muting": false
+        },
+        "rest_id": "2244994945",
+        "super_follow_eligible": false,
+        "super_followed_by": false,
+        "super_following": false,
+        "tipjar_settings": {},
+        "tweet_counts": {
+          "media_tweets": 829,
+          "tweets": 4332
+        },
+        "verification": {
+          "verified": false,
+          "verified_type": "Business"
+        },
+        "website": {
+          "url": "https://t.co/NIwHVIVyrN"
+        }
+      }
+    }
+  }
+}

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -60,7 +60,7 @@ async def test_raise_when_no_account(api_mock: API):
         await gather(api_mock.search("foo", limit=10))
 
     with pytest.raises(NoAccountError):
-        await api_mock.user_by_login("foo")
+        await api_mock.user_by_id(123)
 
     del os.environ["TWS_RAISE_WHEN_NO_ACCOUNT"]
     assert get_env_bool("TWS_RAISE_WHEN_NO_ACCOUNT") is False

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -147,6 +147,30 @@ async def test_search_prints_parsed_tweets(tmp_path, monkeypatch, capsys):
     assert doc["user"]["username"] is not None
 
 
+async def test_user_by_id_prints_parsed_user(tmp_path, monkeypatch, capsys):
+    async def mock_user_by_id_raw(self, uid, kv=None):
+        return fake_rep("raw_user_by_id")
+
+    monkeypatch.setattr(cli.API, "user_by_id_raw", mock_user_by_id_raw)
+
+    args = argparse.Namespace(
+        command="user_by_id",
+        debug=False,
+        db=str(tmp_path / "test.db"),
+        email_first=False,
+        manual=False,
+        raw=False,
+        arg_name="user_id",
+        user_id=2244994945,
+    )
+
+    await cli.main(args)
+
+    doc = json.loads(capsys.readouterr().out.strip())
+    assert doc["id"] == 2244994945
+    assert doc["username"] == "XDevelopers"
+
+
 async def test_user_by_login_prints_parsed_user(tmp_path, monkeypatch, capsys):
     async def mock_user_by_login_raw(self, login, kv=None):
         return fake_rep("raw_user_by_login")

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -250,6 +250,25 @@ async def test_search():
     check_user_field_coverage(users)
 
 
+async def test_user_by_id():
+    api = get_api()
+    mock_rep(api.user_by_id_raw, "raw_user_by_id")
+
+    doc = await api.user_by_id(2244994945)
+    assert doc is not None
+    assert doc.id == 2244994945
+    assert doc.username == "XDevelopers"
+    assert doc.blueType == "Business"
+
+    obj = doc.dict()
+    assert doc.id == obj["id"]
+    assert doc.username == obj["username"]
+
+    txt = doc.json()
+    assert isinstance(txt, str)
+    assert str(doc.id) in txt
+
+
 async def test_user_by_login():
     api = get_api()
     mock_rep(api.user_by_login_raw, "raw_user_by_login")

--- a/tests/test_xclid.py
+++ b/tests/test_xclid.py
@@ -107,14 +107,32 @@ async def test_xclid_curl_client_scopes_cookies_to_x(monkeypatch):
         await client.aclose()
 
 
-def test_logged_out_entry_is_account_error():
+async def test_logged_out_entry_is_account_error():
     html = (
         '<script src="https://abs.twimg.com/x-web/client-web/'
         'entry-client-logged-out-a1b2c3.js"></script>'
     )
 
     with pytest.raises(xclid.XClIdAccountError, match="Logged-out X web app"):
-        xclid.get_scripts_list(html)
+        await xclid.parse_anim_idx(html, MockClient())
+
+
+def test_script_list_combines_direct_and_reconstructed_urls():
+    html = (
+        '<script src="https://abs.twimg.com/x-web/x-web/app-a1b2c3.js"></script>'
+        '<script src="https://abs.twimg.com/responsive-web/client-web/vendor.1234567a.js"></script>'
+        '<script src="/responsive-web/client-web/main.15e48250ae23af9ea.js"></script>'
+        '{100:"shared~feature"}+{100:"00c0ffee00c0ffee"}'
+    )
+
+    urls = xclid.get_scripts_list(html)
+
+    assert urls == [
+        "https://abs.twimg.com/x-web/x-web/app-a1b2c3.js",
+        "https://abs.twimg.com/responsive-web/client-web/vendor.1234567a.js",
+        "https://abs.twimg.com/responsive-web/client-web/main.15e48250ae23af9ea.js",
+        "https://abs.twimg.com/responsive-web/client-web/shared~feature.00c0ffee00c0ffeea.js",
+    ]
 
 
 # In the legacy webpack fixtures the name map comes BEFORE the hash map: hash values

--- a/twscrape/api.py
+++ b/twscrape/api.py
@@ -263,6 +263,28 @@ class API:
                 for x in parse_users(rep.json(), limit):
                     yield x
 
+    # user_by_id
+
+    async def user_by_id_raw(self, uid: int, kv: KV = None):
+        op = OP_UserByRestId
+        kv = {"userId": str(uid), "withSafetyModeUserFields": True, **(kv or {})}
+        ft = {
+            "highlights_tweets_tab_ui_enabled": True,
+            "hidden_profile_likes_enabled": True,
+            "creator_subscriptions_tweet_preview_api_enabled": True,
+            "hidden_profile_subscriptions_enabled": True,
+            "subscriptions_verification_info_verified_since_enabled": True,
+            "subscriptions_verification_info_is_identity_verified_enabled": False,
+            "responsive_web_twitter_article_notes_tab_enabled": False,
+            "subscriptions_feature_can_gift_premium": False,
+            "profile_label_improvements_pcf_label_in_post_enabled": False,
+        }
+        return await self._gql_item(op, kv, ft)
+
+    async def user_by_id(self, uid: int, kv: KV = None) -> User | None:
+        rep = await self.user_by_id_raw(uid, kv=kv)
+        return parse_user(rep) if rep else None
+
     # user_by_login
 
     async def user_by_login_raw(self, login: str, kv: KV = None):

--- a/twscrape/cli.py
+++ b/twscrape/cli.py
@@ -214,6 +214,7 @@ def run():
     c_lim("tweet_replies", "Get replies  of a tweet", "tweet_id", "Tweet ID", int)
     c_lim("tweet_thread", "Get thread tweets", "tweet_id", "Tweet ID", int)
     c_lim("retweeters", "Get retweeters of a tweet", "tweet_id", "Tweet ID", int)
+    c_one("user_by_id", "Get user data by ID", "user_id", "User ID", int)
     c_one("user_by_login", "Get user data by username", "username", "Username")
     c_one("user_about", "Get about info for username", "username", "Username")
     c_lim("following", "Get user following", "user_id", "User ID", int)

--- a/twscrape/xclid.py
+++ b/twscrape/xclid.py
@@ -62,36 +62,30 @@ def script_url(k: str, v: str):
 # Current X web build (Vite): script bundles are linked directly in the page
 # HTML under https://abs.twimg.com/x-web/.../*.js (modulepreload links + entry).
 ASSET_URL_RE = re.compile(r"https://[\w.-]+/x-web/[\w./-]+\.js")
+RESPONSIVE_WEB_URL_RE = re.compile(r"https://[\w.-]+/responsive-web/client-web/[\w./-]+\.js")
+LEGACY_MAIN_RE = re.compile(r"/client-web/main\.([^.\"']+)\.js")
 LOGGED_OUT_ENTRY_RE = re.compile(r"(?:^|/)entry-client-logged-out(?:[-.][^/?#]+)?\.js(?:[?#].*)?$")
 
 
 def get_scripts_list(text: str) -> list[str]:
     """
-    Extract chunk script URLs from the X homepage HTML.
+    Extract all known script URL formats from the X homepage HTML.
 
-    Current build (x-web / Vite): scripts are linked directly in the page HTML,
-    so we just collect those URLs. If none are found we fall back to the legacy
-    webpack build, which embeds two maps in the page and requires URL
-    reconstruction:
+    Current x-web/Vite and responsive-web scripts can be linked directly. The
+    legacy webpack build embeds two maps and requires URL reconstruction:
       - Hash map  {chunk_id: "hexchars"}             values are exactly 7 or 16 lowercase hex digits
       - Name map  {chunk_id: "human_readable_name"}  values contain non-hex characters
       URL format: https://abs.twimg.com/responsive-web/client-web/{name}.{hash}a.js
     """
-    urls = list(dict.fromkeys(ASSET_URL_RE.findall(text)))
-    if urls:
-        if any(LOGGED_OUT_ENTRY_RE.search(url) for url in urls):
-            raise XClIdAccountError("Logged-out X web app")
-        return urls
+    urls = ASSET_URL_RE.findall(text) + RESPONSIVE_WEB_URL_RE.findall(text)
+    if main_match := LEGACY_MAIN_RE.search(text):
+        urls.append(script_url("main", main_match.group(1)))
 
-    # Legacy webpack build fallback.
     # Hash map: values are exactly 7 or 16 lowercase hex digits (7 before 2026-08-24, 16 since;
     # distinguishes them from name-map values)
     hash_map = {
         m.group(1): m.group(2) for m in re.finditer(r'(\d+):"([0-9a-f]{7}|[0-9a-f]{16})"', text)
     }
-
-    if not hash_map:
-        raise XClIdParseError("X web scripts not found")
 
     # Name map: values that are NOT exactly 7 or 16 hex digits (i.e. human-readable chunk names)
     name_map: dict[str, str] = {}
@@ -100,10 +94,13 @@ def get_scripts_list(text: str) -> list[str]:
         if not re.fullmatch(r"[0-9a-f]{7}|[0-9a-f]{16}", val):
             name_map[m.group(1)] = val
 
-    return [
+    urls.extend(
         script_url(name_map.get(chunk_id, chunk_id), hash_val + "a")
         for chunk_id, hash_val in hash_map.items()
-    ]
+    )
+    if not urls:
+        raise XClIdParseError("X web scripts not found")
+    return list(dict.fromkeys(urls))
 
 
 # MARK: XClientTxId parsing
@@ -299,9 +296,12 @@ async def _find_indices_url(scripts: list[str], clt: HttpClient) -> str:
 
 
 async def parse_anim_idx(text: str, clt: HttpClient) -> list[int]:
-    scripts = list(get_scripts_list(text))
-    if not scripts:
-        raise XClIdParseError("X web scripts not found")
+    scripts = get_scripts_list(text)
+    x_web_scripts = [url for url in scripts if "/x-web/" in url]
+    if x_web_scripts:
+        if any(LOGGED_OUT_ENTRY_RE.search(url) for url in x_web_scripts):
+            raise XClIdAccountError("Logged-out X web app")
+        scripts = x_web_scripts
 
     # Legacy build links the indices file directly; the current x-web build
     # hides it behind a dynamic import inside a bundle chunk.


### PR DESCRIPTION
This restores what 6e0db145 removed, but it is not a plain revert: that commit also added an HTML/Cloudflare block detection in `queue_client.py` which is unrelated to `user_by_id` and is left untouched. Compared to v0.17.0, the restored method uses the current `UserByRestId` op ID from the codegen block, an updated feature-flag set (verified against the live endpoint), a freshly captured mock fixture, and adds CLI test coverage that did not exist before.

Fixes #326 