### PR TITLE
Cookie account setup: live validation, browser extraction, multi-profile fix, exit codes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,77 @@
+# AGENTS.md — twscrape (intelogroup fork)
+
+This fork adds cookie-handling fixes on top of upstream `vladkens/twscrape`.
+If you're an agent wiring this into a project, read this first — it covers
+the exact failure modes that cost real debugging time before these fixes
+existed.
+
+## Getting an account working, fastest path
+
+```bash
+pip install "twscrape[curl,browser]"
+twscrape --db path/to/accounts.db add_cookie_local <local_username> --browser chrome
+```
+
+Requires the operator already logged into x.com in that browser. This reads
+`auth_token`/`ct0` straight from the browser's local cookie store — no
+scripted login, no new browser window, no bot-detection surface. Do **not**
+try to automate the X login flow with Playwright/Selenium/CDP — X
+fingerprints `navigator.webdriver` and blocks it; this is why
+`add_cookie_local` exists instead of a headless-login flow.
+
+Check the account actually worked before doing anything else:
+
+```python
+from twscrape import API
+api = API("path/to/accounts.db")
+accs = await api.pool.get_all()
+for a in accs:
+    assert a.active, a.error_msg  # error_msg is human-readable and specific
+```
+
+`add_cookie`/`add_cookie_local` both validate live against X on add — if
+`active` is `False`, `error_msg` tells you why immediately (e.g. `"Logged-out
+X web app"` means the cookies are stale/mismatched — most often caused by
+copying `auth_token` and `ct0` at different moments, or from the wrong
+cookie domain). Don't wait for a real scrape to discover this.
+
+## Manual cookie format (if `add_cookie_local` isn't available)
+
+`twscrape add_cookie <username>` prompts for a cookie string. It must be:
+- **One line**, both values present
+- Literal key names included: `auth_token=<value>; ct0=<value>`
+- Not just the raw values — `<value1>;<value2>` alone will fail with
+  `Invalid cookie value`
+
+## CLI command names
+
+`del_accounts`/`del_account` and `add_cookie`/`add_cookies` both work
+(singular/plural aliases). If a command errors with "invalid choice", check
+`twscrape --help` for the exact current command list rather than guessing.
+
+## Rate limits (real numbers, per account, per endpoint — observed live, may drift)
+
+| Endpoint | Limit | Window |
+|---|---|---|
+| `search` | ~50 requests | 15 min |
+| `user_by_login` / `user_by_id` | ~150 requests | 15 min |
+| `followers` / `following` | ~50 requests | 15 min |
+
+twscrape reads these from X's own `x-rate-limit-*` response headers per
+request and auto-locks an account for that specific endpoint until reset,
+rotating to another active account if the pool has one — no manual backoff
+needed. With a single account, budget calls under the ceiling above; X does
+not publish these numbers officially and they can change.
+
+## Don't
+
+- Don't attempt automated/scripted login (Playwright, Selenium, raw CDP) —
+  gets blocked, wastes time, `add_cookie_local` solves the same problem
+  without triggering bot detection.
+- Don't assume `active=True` at add time means the account is genuinely
+  usable if you bypass the built-in validation (e.g. inserting rows into
+  the accounts DB directly) — the validation only runs through
+  `add_account_cookies()`.
+- Don't hardcode the rate-limit numbers above into retry logic — read the
+  live headers via twscrape's own account-lock behavior instead; the table
+  is for capacity planning, not a guaranteed contract from X.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,7 @@ dependencies = [
 
 [project.optional-dependencies]
 curl = ["curl-cffi>=0.7.0"]
+browser = ["browser-cookie3>=0.19.1"]
 
 [dependency-groups]
 dev = [

--- a/readme.md
+++ b/readme.md
@@ -56,23 +56,42 @@ TWS_HTTP_BACKEND=curl twscrape user_by_login xdevelopers
 
 ## Start With Cookies
 
-twscrape requires authorized X/Twitter accounts. The most stable setup is to add an account from browser cookies containing `auth_token` and `ct0`. The recommended way to export them from your current browser profile is [unjar](https://github.com/vladkens/unjar):
+twscrape requires authorized X/Twitter accounts. The most stable setup is to add an account from browser cookies containing `auth_token` and `ct0`.
+
+**Recommended (this fork): read cookies straight from a local browser, no copy-paste.**
 
 ```bash
-unjar x.com -f header | twscrape add_cookie my_account
+pip install "twscrape[browser]"
+twscrape add_cookie_local my_account --browser chrome  # or firefox, edge, safari, brave, opera, chromium
 twscrape accounts
 twscrape search "from:xdevelopers lang:en" --limit=20
 ```
 
+Requires being logged into x.com in that browser already — nothing is automated beyond reading the local cookie store (via [browser_cookie3](https://github.com/borisbabic/browser_cookie3)). No new browser window opens, no login is scripted. First run on macOS triggers a one-time Keychain permission prompt to decrypt Chrome's cookie store.
+
 `my_account` is a local identifier; twscrape does not verify that it matches the X username stored in the cookies. Run the same command again to replace its saved session while preserving credentials, statistics, locks, and proxy settings.
 
-Alternatively, let the CLI prompt securely for cookies copied from x.com -> DevTools (F12) -> Application -> Cookies:
+Cookies are validated live against X immediately on add — the account log line tells you right away whether it worked (`... updated successfully (validated live)`) or why not (`... stored but NOT active: <reason>`), instead of only surfacing on the first real scrape.
+
+**Alternative: [unjar](https://github.com/vladkens/unjar)**, a separate CLI that also exports cookies from a browser profile:
+
+```bash
+unjar x.com -f header | twscrape add_cookie my_account
+```
+
+**Alternative: manual paste.** Let the CLI prompt securely for cookies copied from x.com -> DevTools (F12) -> Application -> Cookies. Both values must be on **one line**, with the literal key names, e.g. `auth_token=xxx; ct0=yyy` — a common failure mode is pasting just the raw values without the `auth_token=`/`ct0=` prefixes, or pasting them on separate lines (the prompt only reads one line):
 
 ```bash
 twscrape add_cookie my_account
 ```
 
 Cookie accounts that include `auth_token` and `ct0` are activated immediately; no `login_accounts` step is needed.
+
+`del_accounts`/`del_account` and `add_cookie`/`add_cookies` are interchangeable — both singular and plural forms work for either command.
+
+### Rate limits
+
+Limits are per-account, per-endpoint, and set by X — not configurable in twscrape. Observed live (may drift over time): search ~50 requests/15min, user lookup (`user_by_login`/`user_by_id`) ~150 requests/15min, `followers`/`following` ~50 requests/15min. twscrape reads X's own `x-rate-limit-*` response headers and auto-locks an account for that specific endpoint until reset, rotating to another active account if one exists — you don't need to implement backoff yourself, but budget for the ceiling if running a single account.
 
 Ready-to-use cookie accounts are available from [this provider](https://kutt.to/ueeM5f). Proxy users can bring their own proxies or use [this provider](https://kutt.to/eb3rXk). These are referral links.
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,6 +6,7 @@ from twscrape.accounts_pool import AccountsPool
 from twscrape.api import API
 from twscrape.logger import set_log_level
 from twscrape.queue_client import QueueClient, XClIdGenStore
+from twscrape.xclid import XClIdGen
 
 from .mock_http import MockClient
 
@@ -31,7 +32,17 @@ def mock_xclidgenstore(monkeypatch):
 
 
 @pytest.fixture
-def pool_mock(tmp_path):
+def pool_mock(tmp_path, monkeypatch):
+    # add_account_cookies() probes X live via XClIdGen.create() to validate
+    # cookies at add time; default to "succeeds" so pool tests don't hit the
+    # network. Override per-test (monkeypatch.setattr again) to exercise the
+    # failure path. Scoped to pool_mock (not autouse) so it doesn't clobber
+    # test_xclid.py's own tests of the real XClIdGen.create() implementation.
+    async def mock_create(*args, **kwargs):
+        return ClIdGenMock()
+
+    monkeypatch.setattr(XClIdGen, "create", staticmethod(mock_create))
+
     db_path = tmp_path / "test.db"
     yield AccountsPool(db_path)
 

--- a/tests/test_browser_cookies.py
+++ b/tests/test_browser_cookies.py
@@ -17,29 +17,32 @@ class FakeCookie:
 
 
 def install_fake_module(monkeypatch, loader):
-    fake_mod = SimpleNamespace(chrome=loader)
+    # firefox isn't in _MULTI_PROFILE_CLASSES, so this exercises the plain
+    # single-call path — Chromium multi-profile scanning is covered
+    # separately in test_browser_cookies_multiprofile.py.
+    fake_mod = SimpleNamespace(firefox=loader)
     monkeypatch.setitem(sys.modules, "browser_cookie3", fake_mod)
 
 
 def test_get_x_cookies_success(monkeypatch):
-    def fake_chrome(domain_name=None):
+    def fake_firefox(domain_name=None):
         assert domain_name == "x.com"
         return [FakeCookie("auth_token", "tok"), FakeCookie("ct0", "csrf"), FakeCookie("other", "x")]
 
-    install_fake_module(monkeypatch, fake_chrome)
+    install_fake_module(monkeypatch, fake_firefox)
 
-    result = get_x_cookies("chrome")
+    result = get_x_cookies("firefox")
     assert result == {"auth_token": "tok", "ct0": "csrf"}
 
 
 def test_get_x_cookies_missing_required(monkeypatch):
-    def fake_chrome(domain_name=None):
+    def fake_firefox(domain_name=None):
         return [FakeCookie("auth_token", "tok")]
 
-    install_fake_module(monkeypatch, fake_chrome)
+    install_fake_module(monkeypatch, fake_firefox)
 
     with pytest.raises(BrowserCookiesError, match="ct0"):
-        get_x_cookies("chrome")
+        get_x_cookies("firefox")
 
 
 def test_get_x_cookies_unsupported_browser(monkeypatch):
@@ -53,23 +56,23 @@ def test_get_x_cookies_not_installed(monkeypatch):
     monkeypatch.setitem(sys.modules, "browser_cookie3", None)
 
     with pytest.raises(BrowserCookiesError, match="pip install twscrape\\[browser\\]"):
-        get_x_cookies("chrome")
+        get_x_cookies("firefox")
 
 
 def test_get_x_cookies_loader_raises(monkeypatch):
-    def fake_chrome(domain_name=None):
+    def fake_firefox(domain_name=None):
         raise RuntimeError("keychain locked")
 
-    install_fake_module(monkeypatch, fake_chrome)
+    install_fake_module(monkeypatch, fake_firefox)
 
     with pytest.raises(BrowserCookiesError, match="keychain locked"):
-        get_x_cookies("chrome")
+        get_x_cookies("firefox")
 
 
 def test_get_x_cookies_string_format(monkeypatch):
-    def fake_chrome(domain_name=None):
+    def fake_firefox(domain_name=None):
         return [FakeCookie("auth_token", "tok"), FakeCookie("ct0", "csrf")]
 
-    install_fake_module(monkeypatch, fake_chrome)
+    install_fake_module(monkeypatch, fake_firefox)
 
-    assert get_x_cookies_string("chrome") == "auth_token=tok; ct0=csrf"
+    assert get_x_cookies_string("firefox") == "auth_token=tok; ct0=csrf"

--- a/tests/test_browser_cookies.py
+++ b/tests/test_browser_cookies.py
@@ -1,0 +1,75 @@
+import sys
+from types import SimpleNamespace
+
+import pytest
+
+from twscrape.browser_cookies import (
+    BrowserCookiesError,
+    get_x_cookies,
+    get_x_cookies_string,
+)
+
+
+class FakeCookie:
+    def __init__(self, name, value):
+        self.name = name
+        self.value = value
+
+
+def install_fake_module(monkeypatch, loader):
+    fake_mod = SimpleNamespace(chrome=loader)
+    monkeypatch.setitem(sys.modules, "browser_cookie3", fake_mod)
+
+
+def test_get_x_cookies_success(monkeypatch):
+    def fake_chrome(domain_name=None):
+        assert domain_name == "x.com"
+        return [FakeCookie("auth_token", "tok"), FakeCookie("ct0", "csrf"), FakeCookie("other", "x")]
+
+    install_fake_module(monkeypatch, fake_chrome)
+
+    result = get_x_cookies("chrome")
+    assert result == {"auth_token": "tok", "ct0": "csrf"}
+
+
+def test_get_x_cookies_missing_required(monkeypatch):
+    def fake_chrome(domain_name=None):
+        return [FakeCookie("auth_token", "tok")]
+
+    install_fake_module(monkeypatch, fake_chrome)
+
+    with pytest.raises(BrowserCookiesError, match="ct0"):
+        get_x_cookies("chrome")
+
+
+def test_get_x_cookies_unsupported_browser(monkeypatch):
+    install_fake_module(monkeypatch, lambda domain_name=None: [])
+
+    with pytest.raises(BrowserCookiesError, match="Unsupported browser"):
+        get_x_cookies("netscape-navigator")
+
+
+def test_get_x_cookies_not_installed(monkeypatch):
+    monkeypatch.setitem(sys.modules, "browser_cookie3", None)
+
+    with pytest.raises(BrowserCookiesError, match="pip install twscrape\\[browser\\]"):
+        get_x_cookies("chrome")
+
+
+def test_get_x_cookies_loader_raises(monkeypatch):
+    def fake_chrome(domain_name=None):
+        raise RuntimeError("keychain locked")
+
+    install_fake_module(monkeypatch, fake_chrome)
+
+    with pytest.raises(BrowserCookiesError, match="keychain locked"):
+        get_x_cookies("chrome")
+
+
+def test_get_x_cookies_string_format(monkeypatch):
+    def fake_chrome(domain_name=None):
+        return [FakeCookie("auth_token", "tok"), FakeCookie("ct0", "csrf")]
+
+    install_fake_module(monkeypatch, fake_chrome)
+
+    assert get_x_cookies_string("chrome") == "auth_token=tok; ct0=csrf"

--- a/tests/test_browser_cookies_multiprofile.py
+++ b/tests/test_browser_cookies_multiprofile.py
@@ -92,6 +92,33 @@ def test_no_profile_has_full_session_reports_count(tmp_path, monkeypatch):
         get_x_cookies("chrome")
 
 
+def test_all_profiles_fail_to_load_surfaces_real_error(tmp_path, monkeypatch):
+    # Distinct from "checked N profiles, none had a session" — every
+    # profile errored out (e.g. keychain access denied), so the real cause
+    # should surface instead of the generic "no session found" message.
+    user_data = tmp_path / "User Data"
+    default_cookies = user_data / "Default" / "Cookies"
+    profile1_cookies = user_data / "Profile 1" / "Cookies"
+    for p in (default_cookies, profile1_cookies):
+        p.parent.mkdir(parents=True)
+        p.touch()
+
+    class DeniedInstance(FakeChromeInstance):
+        def load(self):
+            raise PermissionError("Keychain access denied")
+
+    def make_instance(domain_name=None):
+        return DeniedInstance({}, str(default_cookies), domain_name)
+
+    fake_mod = type(sys)("browser_cookie3")
+    fake_mod.chrome = lambda domain_name=None: make_instance(domain_name).load()
+    fake_mod.Chrome = make_instance
+    monkeypatch.setitem(sys.modules, "browser_cookie3", fake_mod)
+
+    with pytest.raises(BrowserCookiesError, match="Keychain access denied"):
+        get_x_cookies("chrome")
+
+
 def test_default_profile_wins_when_it_has_the_session(tmp_path, monkeypatch):
     user_data = tmp_path / "User Data"
     default_cookies = user_data / "Default" / "Cookies"

--- a/tests/test_browser_cookies_multiprofile.py
+++ b/tests/test_browser_cookies_multiprofile.py
@@ -1,0 +1,111 @@
+"""Covers the real bug found by testing against an actual multi-profile
+Chrome install: browser_cookie3's chrome()/edge()/brave()/chromium() only
+ever resolve the "Default" profile's Cookies file (first glob match wins).
+A user whose X session lives in "Profile 2" would silently get missing or
+wrong cookies with no indication why. These tests simulate that exact
+layout without touching a real browser profile."""
+
+import sys
+
+import pytest
+
+from twscrape.browser_cookies import BrowserCookiesError, get_x_cookies
+
+
+class FakeCookie:
+    def __init__(self, name, value):
+        self.name = name
+        self.value = value
+
+
+class FakeChromeInstance:
+    """Stands in for browser_cookie3.Chrome: cookie_file gets swapped and
+    .load() re-read, matching how the real class behaves."""
+
+    def __init__(self, jars_by_path, default_path, domain_name=None):
+        self._jars_by_path = jars_by_path
+        self.cookie_file = default_path
+        self.domain_name = domain_name
+
+    def load(self):
+        jar = self._jars_by_path.get(self.cookie_file)
+        if jar is None:
+            raise FileNotFoundError(self.cookie_file)
+        return jar
+
+
+def install_fake_chrome_class(monkeypatch, profile_paths, jars_by_profile, default_index=0):
+    """profile_paths: list of Path objects under one User Data dir, in the
+    order Default should be checked first, then Profile 1, Profile 2, ...
+    jars_by_profile: dict[Path, list[FakeCookie]] — only profiles with a
+    findable session need an entry."""
+    jars_by_path = {str(p): jar for p, jar in jars_by_profile.items()}
+    default_path = str(profile_paths[default_index])
+
+    def make_instance(domain_name=None):
+        return FakeChromeInstance(jars_by_path, default_path, domain_name)
+
+    fake_mod = type(sys)("browser_cookie3")
+    fake_mod.chrome = lambda domain_name=None: make_instance(domain_name).load()
+    fake_mod.Chrome = make_instance
+    monkeypatch.setitem(sys.modules, "browser_cookie3", fake_mod)
+
+
+def test_session_in_non_default_profile_is_found(tmp_path, monkeypatch):
+    # Layout: Default has no x.com session at all, Profile 2 has the real one.
+    user_data = tmp_path / "User Data"
+    default_cookies = user_data / "Default" / "Cookies"
+    profile1_cookies = user_data / "Profile 1" / "Cookies"
+    profile2_cookies = user_data / "Profile 2" / "Cookies"
+    for p in (default_cookies, profile1_cookies, profile2_cookies):
+        p.parent.mkdir(parents=True)
+        p.touch()
+
+    jars = {
+        default_cookies: [],  # no x.com cookies here
+        profile1_cookies: [FakeCookie("ct0", "csrf-only")],  # partial, missing auth_token
+        profile2_cookies: [FakeCookie("auth_token", "real-token"), FakeCookie("ct0", "real-csrf")],
+    }
+    install_fake_chrome_class(
+        monkeypatch, [default_cookies, profile1_cookies, profile2_cookies], jars
+    )
+
+    result = get_x_cookies("chrome")
+    assert result == {"auth_token": "real-token", "ct0": "real-csrf"}
+
+
+def test_no_profile_has_full_session_reports_count(tmp_path, monkeypatch):
+    user_data = tmp_path / "User Data"
+    default_cookies = user_data / "Default" / "Cookies"
+    profile1_cookies = user_data / "Profile 1" / "Cookies"
+    for p in (default_cookies, profile1_cookies):
+        p.parent.mkdir(parents=True)
+        p.touch()
+
+    jars = {
+        default_cookies: [],
+        profile1_cookies: [FakeCookie("ct0", "csrf-only")],  # partial only, never completes
+    }
+    install_fake_chrome_class(monkeypatch, [default_cookies, profile1_cookies], jars)
+
+    with pytest.raises(BrowserCookiesError, match=r"2 chrome profile\(s\) checked"):
+        get_x_cookies("chrome")
+
+
+def test_default_profile_wins_when_it_has_the_session(tmp_path, monkeypatch):
+    user_data = tmp_path / "User Data"
+    default_cookies = user_data / "Default" / "Cookies"
+    profile1_cookies = user_data / "Profile 1" / "Cookies"
+    for p in (default_cookies, profile1_cookies):
+        p.parent.mkdir(parents=True)
+        p.touch()
+
+    jars = {
+        default_cookies: [FakeCookie("auth_token", "default-token"), FakeCookie("ct0", "default-csrf")],
+        profile1_cookies: [FakeCookie("auth_token", "other-token"), FakeCookie("ct0", "other-csrf")],
+    }
+    install_fake_chrome_class(monkeypatch, [default_cookies, profile1_cookies], jars)
+
+    result = get_x_cookies("chrome")
+    # Default checked first — should win even though Profile 1 also has a full session.
+    assert result == {"auth_token": "default-token", "ct0": "default-csrf"}

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,11 +1,19 @@
 import argparse
 import io
 import json
+from types import SimpleNamespace
 
 import pytest
 
 from tests.test_parser import fake_rep
 from twscrape import cli
+
+
+def mock_get_returning(monkeypatch, *, active: bool):
+    async def mock_get(self, username):
+        return SimpleNamespace(username=username, active=active)
+
+    monkeypatch.setattr(cli.AccountsPool, "get", mock_get)
 
 
 async def test_add_cookie_uses_arg_cookies(tmp_path, monkeypatch):
@@ -16,6 +24,7 @@ async def test_add_cookie_uses_arg_cookies(tmp_path, monkeypatch):
         called["cookies"] = cookies
 
     monkeypatch.setattr(cli.AccountsPool, "add_account_cookies", mock_add_account_cookies)
+    mock_get_returning(monkeypatch, active=True)
 
     args = argparse.Namespace(
         command="add_cookie",
@@ -32,6 +41,29 @@ async def test_add_cookie_uses_arg_cookies(tmp_path, monkeypatch):
     assert called == {"username": "user1", "cookies": "auth_token=token; ct0=csrf"}
 
 
+async def test_add_cookie_exits_nonzero_when_validation_fails(tmp_path, monkeypatch):
+    async def mock_add_account_cookies(self, username, cookies):
+        pass
+
+    monkeypatch.setattr(cli.AccountsPool, "add_account_cookies", mock_add_account_cookies)
+    mock_get_returning(monkeypatch, active=False)
+
+    args = argparse.Namespace(
+        command="add_cookie",
+        debug=False,
+        db=str(tmp_path / "test.db"),
+        email_first=False,
+        manual=False,
+        username="user1",
+        cookies="auth_token=stale; ct0=stale",
+    )
+
+    with pytest.raises(SystemExit) as exc_info:
+        await cli.main(args)
+
+    assert exc_info.value.code == 1
+
+
 async def test_add_cookie_prompts_securely_when_missing(tmp_path, monkeypatch):
     called = {}
 
@@ -46,6 +78,7 @@ async def test_add_cookie_prompts_securely_when_missing(tmp_path, monkeypatch):
     monkeypatch.setattr(cli.AccountsPool, "add_account_cookies", mock_add_account_cookies)
     monkeypatch.setattr(cli.getpass, "getpass", mock_getpass)
     monkeypatch.setattr(cli.sys.stdin, "isatty", lambda: True)
+    mock_get_returning(monkeypatch, active=True)
 
     args = argparse.Namespace(
         command="add_cookie",
@@ -75,6 +108,7 @@ async def test_add_cookie_reads_stdin(tmp_path, monkeypatch):
 
     monkeypatch.setattr(cli.AccountsPool, "add_account_cookies", mock_add_account_cookies)
     monkeypatch.setattr(cli.sys, "stdin", io.StringIO("auth_token=token; ct0=csrf\n"))
+    mock_get_returning(monkeypatch, active=True)
 
     args = argparse.Namespace(
         command="add_cookie",
@@ -106,6 +140,7 @@ async def test_add_cookie_local_uses_browser_cookies(tmp_path, monkeypatch):
     monkeypatch.setattr(
         "twscrape.browser_cookies.get_x_cookies_string", mock_get_x_cookies_string
     )
+    mock_get_returning(monkeypatch, active=True)
 
     args = argparse.Namespace(
         command="add_cookie_local",
@@ -126,7 +161,7 @@ async def test_add_cookie_local_uses_browser_cookies(tmp_path, monkeypatch):
     }
 
 
-async def test_add_cookie_local_reports_error(tmp_path, monkeypatch, capsys):
+async def test_add_cookie_local_extraction_failure_exits_nonzero(tmp_path, monkeypatch):
     from twscrape.browser_cookies import BrowserCookiesError
 
     async def fail_if_called(self, username, cookies):
@@ -150,7 +185,37 @@ async def test_add_cookie_local_reports_error(tmp_path, monkeypatch, capsys):
         browser="chrome",
     )
 
-    await cli.main(args)
+    with pytest.raises(SystemExit) as exc_info:
+        await cli.main(args)
+
+    assert exc_info.value.code == 1
+
+
+async def test_add_cookie_local_validation_failure_exits_nonzero(tmp_path, monkeypatch):
+    async def mock_add_account_cookies(self, username, cookies):
+        pass
+
+    monkeypatch.setattr(cli.AccountsPool, "add_account_cookies", mock_add_account_cookies)
+    monkeypatch.setattr(
+        "twscrape.browser_cookies.get_x_cookies_string",
+        lambda browser: "auth_token=stale; ct0=stale",
+    )
+    mock_get_returning(monkeypatch, active=False)
+
+    args = argparse.Namespace(
+        command="add_cookie_local",
+        debug=False,
+        db=str(tmp_path / "test.db"),
+        email_first=False,
+        manual=False,
+        username="user1",
+        browser="chrome",
+    )
+
+    with pytest.raises(SystemExit) as exc_info:
+        await cli.main(args)
+
+    assert exc_info.value.code == 1
 
 
 async def test_add_accounts_prints_next_step(tmp_path, monkeypatch, capsys):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -91,6 +91,68 @@ async def test_add_cookie_reads_stdin(tmp_path, monkeypatch):
     assert called == {"username": "user1", "cookies": "auth_token=token; ct0=csrf"}
 
 
+async def test_add_cookie_local_uses_browser_cookies(tmp_path, monkeypatch):
+    called = {}
+
+    async def mock_add_account_cookies(self, username, cookies):
+        called["username"] = username
+        called["cookies"] = cookies
+
+    def mock_get_x_cookies_string(browser):
+        called["browser"] = browser
+        return "auth_token=tok; ct0=csrf"
+
+    monkeypatch.setattr(cli.AccountsPool, "add_account_cookies", mock_add_account_cookies)
+    monkeypatch.setattr(
+        "twscrape.browser_cookies.get_x_cookies_string", mock_get_x_cookies_string
+    )
+
+    args = argparse.Namespace(
+        command="add_cookie_local",
+        debug=False,
+        db=str(tmp_path / "test.db"),
+        email_first=False,
+        manual=False,
+        username="user1",
+        browser="chrome",
+    )
+
+    await cli.main(args)
+
+    assert called == {
+        "username": "user1",
+        "cookies": "auth_token=tok; ct0=csrf",
+        "browser": "chrome",
+    }
+
+
+async def test_add_cookie_local_reports_error(tmp_path, monkeypatch, capsys):
+    from twscrape.browser_cookies import BrowserCookiesError
+
+    async def fail_if_called(self, username, cookies):
+        pytest.fail("add_account_cookies should not be called on extraction failure")
+
+    def mock_get_x_cookies_string(browser):
+        raise BrowserCookiesError("no active x.com session")
+
+    monkeypatch.setattr(cli.AccountsPool, "add_account_cookies", fail_if_called)
+    monkeypatch.setattr(
+        "twscrape.browser_cookies.get_x_cookies_string", mock_get_x_cookies_string
+    )
+
+    args = argparse.Namespace(
+        command="add_cookie_local",
+        debug=False,
+        db=str(tmp_path / "test.db"),
+        email_first=False,
+        manual=False,
+        username="user1",
+        browser="chrome",
+    )
+
+    await cli.main(args)
+
+
 async def test_add_accounts_prints_next_step(tmp_path, monkeypatch, capsys):
     called = {}
 

--- a/tests/test_pool.py
+++ b/tests/test_pool.py
@@ -3,6 +3,7 @@ import pytest
 from twscrape.accounts_pool import AccountsPool, NoAccountError
 from twscrape.api import API
 from twscrape.utils import utc
+from twscrape.xclid import XClIdAccountError, XClIdGen
 
 
 async def test_add_accounts(pool_mock: AccountsPool):
@@ -48,6 +49,21 @@ async def test_add_account_cookies(pool_mock: AccountsPool):
     assert acc.active is True
     assert acc.has_session is True
     assert acc.login_method == "cookies"
+
+
+async def test_add_account_cookies_validation_fails(pool_mock: AccountsPool, monkeypatch):
+    async def mock_create(*args, **kwargs):
+        raise XClIdAccountError("Logged-out X web app")
+
+    monkeypatch.setattr(XClIdGen, "create", staticmethod(mock_create))
+
+    await pool_mock.add_account_cookies("user1", "auth_token=token; ct0=csrf")
+    acc = await pool_mock.get("user1")
+
+    assert acc.active is False
+    assert acc.error_msg == "Logged-out X web app"
+    # cookies still stored so a fresh add_cookie retry can reuse the same account
+    assert acc.cookies == {"auth_token": "token", "ct0": "csrf"}
 
 
 @pytest.mark.parametrize(

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -29,6 +29,24 @@ def test_cookies_parse():
         assert parse_cookies(val) == {}
 
 
+def test_cookies_parse_strips_quotes():
+    # Common paste artifact from some cookie-export tools/extensions —
+    # quoted values otherwise become part of the literal cookie value.
+    assert parse_cookies('auth_token="tok"; ct0="csrf"') == {
+        "auth_token": "tok",
+        "ct0": "csrf",
+    }
+    assert parse_cookies("auth_token='tok'; ct0='csrf'") == {
+        "auth_token": "tok",
+        "ct0": "csrf",
+    }
+    # Mismatched quotes aren't stripped — could be a legitimately quote-containing value.
+    assert parse_cookies('auth_token="tok\'; ct0=csrf') == {
+        "auth_token": '"tok\'',
+        "ct0": "csrf",
+    }
+
+
 def test_proxy_parse():
     assert parse_proxy(None) is None
     assert parse_proxy("") is None

--- a/twscrape/accounts_pool.py
+++ b/twscrape/accounts_pool.py
@@ -139,7 +139,11 @@ class AccountsPool:
         except XClIdError as e:
             active, error_msg = False, str(e)
         except Exception as e:
-            active, error_msg = False, f"Validation request failed: {e}"
+            # Not an XClIdError (auth/parse problem) — likely network/proxy/DNS.
+            # Keep the exception class name so it's distinguishable from the
+            # XClIdError branch above without re-raising and losing the
+            # active/error_msg bookkeeping below.
+            active, error_msg = False, f"Validation request failed: {type(e).__name__}: {e}"
 
         qs = """
         INSERT INTO accounts

--- a/twscrape/accounts_pool.py
+++ b/twscrape/accounts_pool.py
@@ -11,6 +11,7 @@ from .http import HttpStatusError
 from .logger import logger
 from .login import LoginConfig, login
 from .utils import get_env_bool, parse_cookies, utc
+from .xclid import XClIdError, XClIdGen
 
 
 class NoAccountError(Exception):
@@ -124,22 +125,44 @@ class AccountsPool:
         await self.save(account)
         logger.info(f"Account {username} added successfully (active={account.active})")
 
-    async def add_account_cookies(self, username: str, cookies: str):
+    async def add_account_cookies(self, username: str, cookies: str, proxy: str | None = None):
         parsed = parse_cookies(cookies)
         if not has_required_cookies(parsed):
             raise ValueError("Cookies must include auth_token and ct0")
 
+        # Probe X immediately instead of trusting the cookies blindly — a stale or
+        # mismatched auth_token/ct0 pair otherwise looks "active" until the first
+        # real scrape fails minutes later with no clue why.
+        active, error_msg = True, None
+        try:
+            await XClIdGen.create(proxy=proxy, cookies=parsed)
+        except XClIdError as e:
+            active, error_msg = False, str(e)
+        except Exception as e:
+            active, error_msg = False, f"Validation request failed: {e}"
+
         qs = """
-        INSERT INTO accounts (username, password, email, email_password, user_agent, active, cookies)
-        VALUES (:username, '_', '_', '_', '@chrome', true, :cookies)
+        INSERT INTO accounts
+            (username, password, email, email_password, user_agent, active, cookies, error_msg)
+        VALUES (:username, '_', '_', '_', '@chrome', :active, :cookies, :error_msg)
         ON CONFLICT(username) DO UPDATE SET
             cookies = excluded.cookies,
             headers = '{}',
-            active = true,
-            error_msg = NULL
+            active = excluded.active,
+            error_msg = excluded.error_msg
         """
-        await execute(self._db_file, qs, {"username": username, "cookies": json.dumps(parsed)})
-        logger.info(f"Cookies for account {username} updated successfully")
+        params = {
+            "username": username,
+            "cookies": json.dumps(parsed),
+            "active": active,
+            "error_msg": error_msg,
+        }
+        await execute(self._db_file, qs, params)
+
+        if active:
+            logger.info(f"Cookies for account {username} updated successfully (validated live)")
+        else:
+            logger.warning(f"Cookies for account {username} stored but NOT active: {error_msg}")
 
     async def delete_accounts(self, usernames: str | list[str]):
         usernames = usernames if isinstance(usernames, list) else [usernames]

--- a/twscrape/browser_cookies.py
+++ b/twscrape/browser_cookies.py
@@ -83,23 +83,34 @@ def _profile_cookie_files(default_cookie_file: str) -> list[Path]:
 
 def _load_multi_profile(cls: type, domain_name: str) -> tuple:
     """Try every Chromium-family profile in order, return the jar from the
-    first one containing both required cookies. Returns (jar, tried_count)."""
+    first one containing both required cookies. Returns (jar, tried_count).
+
+    Raises the last per-profile exception if EVERY profile failed to even
+    load (e.g. keychain access denied entirely) — that's a distinct failure
+    from "checked N profiles, none had an x.com session", and collapsing
+    them into the same generic message hides a fixable permission problem
+    behind what looks like a login problem.
+    """
     inst = cls(domain_name=domain_name)  # resolves Default path, derives decrypt key once
     profiles = _profile_cookie_files(inst.cookie_file)
 
-    tried = 0
+    loaded, last_error = 0, None
     for cookie_file in profiles:
         inst.cookie_file = str(cookie_file)
         try:
             jar = inst.load()
-        except Exception:
+        except Exception as e:
+            last_error = e
             continue
-        tried += 1
+        loaded += 1
         names = {c.name for c in jar}
         if all(r in names for r in REQUIRED_COOKIES):
-            return jar, tried
+            return jar, loaded
 
-    return None, max(tried, len(profiles))
+    if loaded == 0 and last_error is not None and profiles:
+        raise last_error
+
+    return None, max(loaded, len(profiles))
 
 
 def get_x_cookies(browser: str = "chrome") -> dict[str, str]:

--- a/twscrape/browser_cookies.py
+++ b/twscrape/browser_cookies.py
@@ -7,6 +7,7 @@ already authenticated by hand, the same way tools like yt-dlp's
 --cookies-from-browser do.
 """
 
+from pathlib import Path
 from typing import Callable
 
 REQUIRED_COOKIES = ("auth_token", "ct0")
@@ -22,6 +23,16 @@ _LOADERS: dict[str, str] = {
     "brave": "brave",
     "opera": "opera",
 }
+
+# browser_cookie3's convenience functions (chrome(), edge(), ...) only ever
+# resolve to the FIRST matching profile path on disk — "Default" beats
+# "Profile 1", "Profile 2", etc. because it's listed first internally. A
+# user whose X session lives in a non-default profile (very common — work
+# vs personal Chrome profiles) gets silently wrong or missing cookies with
+# no error. These four share Chromium's "User Data/<Profile>/Cookies"
+# layout, so for them we scan every sibling profile ourselves instead of
+# trusting the single path browser_cookie3 would have picked.
+_MULTI_PROFILE_CLASSES = {"chrome", "chromium", "edge", "brave"}
 
 
 class BrowserCookiesError(Exception): ...
@@ -41,7 +52,54 @@ def _get_loader(browser: str) -> Callable:
             f"Unsupported browser '{browser}'. Choose from: {', '.join(_LOADERS)}"
         )
 
-    return getattr(browser_cookie3, name)
+    loader = getattr(browser_cookie3, name)
+    cls = getattr(browser_cookie3, name.capitalize()) if name in _MULTI_PROFILE_CLASSES else None
+    return loader, cls
+
+
+def _profile_cookie_files(default_cookie_file: str) -> list[Path]:
+    """Given the resolved 'Default' profile Cookies path, find sibling
+    profile Cookies files (Profile 1, Profile 2, ... and their newer
+    Network/Cookies variant) under the same User Data root."""
+    default_path = Path(default_cookie_file)
+    # .../User Data/Default/Cookies -> user_data_dir = .../User Data
+    # .../User Data/Default/Network/Cookies -> same, one level deeper
+    user_data_dir = default_path.parent.parent
+    if default_path.parent.name == "Network":
+        user_data_dir = user_data_dir.parent
+
+    candidates = [default_path]
+    candidates += sorted(user_data_dir.glob("Profile */Cookies"))
+    candidates += sorted(user_data_dir.glob("Profile */Network/Cookies"))
+    # de-dupe while preserving order (Default first)
+    seen: set[Path] = set()
+    ordered = []
+    for c in candidates:
+        if c not in seen and c.is_file():
+            seen.add(c)
+            ordered.append(c)
+    return ordered
+
+
+def _load_multi_profile(cls: type, domain_name: str) -> tuple:
+    """Try every Chromium-family profile in order, return the jar from the
+    first one containing both required cookies. Returns (jar, tried_count)."""
+    inst = cls(domain_name=domain_name)  # resolves Default path, derives decrypt key once
+    profiles = _profile_cookie_files(inst.cookie_file)
+
+    tried = 0
+    for cookie_file in profiles:
+        inst.cookie_file = str(cookie_file)
+        try:
+            jar = inst.load()
+        except Exception:
+            continue
+        tried += 1
+        names = {c.name for c in jar}
+        if all(r in names for r in REQUIRED_COOKIES):
+            return jar, tried
+
+    return None, max(tried, len(profiles))
 
 
 def get_x_cookies(browser: str = "chrome") -> dict[str, str]:
@@ -49,9 +107,26 @@ def get_x_cookies(browser: str = "chrome") -> dict[str, str]:
 
     Raises BrowserCookiesError if the browser/profile can't be read (locked
     keychain, browser not installed, no active x.com session) or the
-    required cookies aren't present (user isn't logged in).
+    required cookies aren't present (user isn't logged in — checked across
+    every profile for Chromium-family browsers, since the login may not be
+    in the default one).
     """
-    loader = _get_loader(browser)
+    browser_key = browser.lower()
+    loader, cls = _get_loader(browser)
+
+    if browser_key in _MULTI_PROFILE_CLASSES:
+        try:
+            jar, profiles_checked = _load_multi_profile(cls, "x.com")
+        except Exception as e:
+            raise BrowserCookiesError(f"Could not read {browser} cookies: {e}") from e
+
+        if jar is None:
+            raise BrowserCookiesError(
+                f"No x.com session with both {' and '.join(REQUIRED_COOKIES)} found in "
+                f"any of {profiles_checked} {browser} profile(s) checked — make sure "
+                f"you're logged into x.com in one of them"
+            )
+        return {c.name: c.value for c in jar if c.name in REQUIRED_COOKIES}
 
     try:
         jar = loader(domain_name="x.com")

--- a/twscrape/browser_cookies.py
+++ b/twscrape/browser_cookies.py
@@ -1,0 +1,74 @@
+"""Read X session cookies straight from a local browser's cookie store.
+
+No CDP, no automated login, no new browser instance — X fingerprints
+navigator.webdriver and blocks Playwright/CDP-driven login flows, so this
+avoids that fight entirely by reading the cookies of a session the user
+already authenticated by hand, the same way tools like yt-dlp's
+--cookies-from-browser do.
+"""
+
+from typing import Callable
+
+REQUIRED_COOKIES = ("auth_token", "ct0")
+
+# domain_name kwarg narrows browser_cookie3's scan to x.com cookies only,
+# so it never touches unrelated site cookies in the user's browser.
+_LOADERS: dict[str, str] = {
+    "chrome": "chrome",
+    "chromium": "chromium",
+    "firefox": "firefox",
+    "edge": "edge",
+    "safari": "safari",
+    "brave": "brave",
+    "opera": "opera",
+}
+
+
+class BrowserCookiesError(Exception): ...
+
+
+def _get_loader(browser: str) -> Callable:
+    try:
+        import browser_cookie3
+    except ImportError as e:
+        raise BrowserCookiesError(
+            "browser_cookie3 not installed. Install with: pip install twscrape[browser]"
+        ) from e
+
+    name = _LOADERS.get(browser.lower())
+    if name is None:
+        raise BrowserCookiesError(
+            f"Unsupported browser '{browser}'. Choose from: {', '.join(_LOADERS)}"
+        )
+
+    return getattr(browser_cookie3, name)
+
+
+def get_x_cookies(browser: str = "chrome") -> dict[str, str]:
+    """Extract auth_token + ct0 for x.com from the given local browser.
+
+    Raises BrowserCookiesError if the browser/profile can't be read (locked
+    keychain, browser not installed, no active x.com session) or the
+    required cookies aren't present (user isn't logged in).
+    """
+    loader = _get_loader(browser)
+
+    try:
+        jar = loader(domain_name="x.com")
+    except Exception as e:
+        raise BrowserCookiesError(f"Could not read {browser} cookies: {e}") from e
+
+    found = {c.name: c.value for c in jar if c.name in REQUIRED_COOKIES}
+    missing = [name for name in REQUIRED_COOKIES if name not in found]
+    if missing:
+        raise BrowserCookiesError(
+            f"Missing {', '.join(missing)} in {browser}'s x.com cookies — "
+            "make sure you're logged into x.com in that browser"
+        )
+
+    return found
+
+
+def get_x_cookies_string(browser: str = "chrome") -> str:
+    cookies = get_x_cookies(browser)
+    return "; ".join(f"{k}={v}" for k, v in cookies.items())

--- a/twscrape/cli.py
+++ b/twscrape/cli.py
@@ -94,6 +94,18 @@ async def main(args):
         await pool.add_account_cookies(args.username, cookies)
         return
 
+    if args.command == "add_cookie_local":
+        from .browser_cookies import BrowserCookiesError, get_x_cookies_string
+
+        try:
+            cookies = get_x_cookies_string(args.browser)
+        except BrowserCookiesError as e:
+            logger.error(str(e))
+            return
+
+        await pool.add_account_cookies(args.username, cookies)
+        return
+
     if args.command == "del_accounts":
         await pool.delete_accounts(args.usernames)
         return
@@ -194,6 +206,17 @@ def run():
     )
     add_cookie.add_argument("username", help="Local account identifier")
     add_cookie.add_argument("cookies", nargs="?", default=None, help="Cookie string or stdin")
+
+    add_cookie_local = subparsers.add_parser(
+        "add_cookie_local",
+        help="Add one account by reading cookies from a local browser (requires twscrape[browser])",
+    )
+    add_cookie_local.add_argument("username", help="Local account identifier")
+    add_cookie_local.add_argument(
+        "--browser",
+        default="chrome",
+        help="Browser to read x.com cookies from (chrome, chromium, firefox, edge, safari, brave, opera)",
+    )
 
     del_accounts = subparsers.add_parser(
         "del_accounts", aliases=["del_account"], help="Delete accounts by username"

--- a/twscrape/cli.py
+++ b/twscrape/cli.py
@@ -189,11 +189,15 @@ def run():
     add_accounts.add_argument("file_path", help="File with accounts")
     add_accounts.add_argument("line_format", help="Account fields separated by delimiter")
 
-    add_cookie = subparsers.add_parser("add_cookie", help="Add one account from cookies")
+    add_cookie = subparsers.add_parser(
+        "add_cookie", aliases=["add_cookies"], help="Add one account from cookies"
+    )
     add_cookie.add_argument("username", help="Local account identifier")
     add_cookie.add_argument("cookies", nargs="?", default=None, help="Cookie string or stdin")
 
-    del_accounts = subparsers.add_parser("del_accounts", help="Delete accounts by username")
+    del_accounts = subparsers.add_parser(
+        "del_accounts", aliases=["del_account"], help="Delete accounts by username"
+    )
     del_accounts.add_argument("usernames", nargs="+", default=[], help="Usernames to delete")
 
     login_cmd = subparsers.add_parser("login_accounts", help="Log in inactive accounts")
@@ -236,6 +240,10 @@ def run():
     args = p.parse_args()
     if args.command is None:
         return custom_help(p)
+
+    # Subparser aliases keep whatever name was typed, not the canonical one.
+    command_aliases = {"add_cookies": "add_cookie", "del_account": "del_accounts"}
+    args.command = command_aliases.get(args.command, args.command)
 
     try:
         asyncio.run(_run(args))

--- a/twscrape/cli.py
+++ b/twscrape/cli.py
@@ -92,6 +92,10 @@ async def main(args):
                 else sys.stdin.read().strip()
             )
         await pool.add_account_cookies(args.username, cookies)
+
+        account = await pool.get(args.username)
+        if not account.active:
+            sys.exit(1)
         return
 
     if args.command == "add_cookie_local":
@@ -101,9 +105,16 @@ async def main(args):
             cookies = get_x_cookies_string(args.browser)
         except BrowserCookiesError as e:
             logger.error(str(e))
-            return
+            sys.exit(1)
 
         await pool.add_account_cookies(args.username, cookies)
+
+        account = await pool.get(args.username)
+        if not account.active:
+            # Extraction succeeded but X rejected the cookies (validated live
+            # in add_account_cookies) — still a failure an agent needs to see
+            # in the exit code, not just in the log line.
+            sys.exit(1)
         return
 
     if args.command == "del_accounts":

--- a/twscrape/utils.py
+++ b/twscrape/utils.py
@@ -378,7 +378,23 @@ def parse_cookies(val: str) -> dict[str, str]:
     try:
         res = json.loads(val)
     except json.JSONDecodeError:
-        res = dict(x.strip().split("=", 1) for x in val.split(";") if "=" in x)
+        # Strip a matching pair of surrounding quotes per value — a common
+        # paste artifact (some cookie-export tools/extensions quote values)
+        # that otherwise silently becomes part of the literal cookie value
+        # sent to X, producing a confusing auth failure with no hint that
+        # quoting is the actual problem.
+        def _unquote(s: str) -> str:
+            s = s.strip()
+            if len(s) >= 2 and s[0] == s[-1] and s[0] in "\"'":
+                return s[1:-1]
+            return s
+
+        res = {}
+        for x in val.split(";"):
+            if "=" not in x:
+                continue
+            name, value = x.split("=", 1)
+            res[_unquote(name)] = _unquote(value)
 
     # Unwrap browser extension exports.
     if isinstance(res, dict) and "cookies" in res:


### PR DESCRIPTION
## Summary

While integrating twscrape into a real project (following up on #330), hit a series of cookie-account setup failures that cost real debugging time — none were the original `XClIdParseError` bug (fixed in v0.20.1), but adjacent friction in the `add_cookie` path itself. This PR fixes what was actually found and verified, one commit per fix:

- **Live validation at `add_cookie` time** — `add_account_cookies()` stored cookies and marked `active=true` unconditionally, with no check that X actually accepts them. A stale/mismatched `auth_token`/`ct0` pair looked "active" until the first real scrape failed later with no clue why (the exact confusion in #285's "active=False, no clear reason" class of reports). Now probes X immediately via `XClIdGen.create()` and sets `active`/`error_msg` from the real result.

- **`add_cookie_local`** — reads `auth_token`/`ct0` straight from a local browser's cookie store via [`browser_cookie3`](https://github.com/borisbabic/browser_cookie3) (optional `twscrape[browser]` extra), same technique as yt-dlp's `--cookies-from-browser`. No new browser window, no scripted login. This directly addresses #253 ("automate login without copy-pasting cookies?") and sidesteps #278 (Playwright-based login gets Cloudflare-blocked) entirely — nothing is automated beyond reading a session the user already authenticated by hand.

- **Multi-profile Chrome/Chromium/Edge/Brave fix** — found by testing against a real 6-profile Chrome install: `browser_cookie3`'s `chrome()`/`edge()`/`brave()`/`chromium()` only ever resolve the first matching cookie file, and `Default` is checked before `Profile 1`, `Profile 2`, etc. A user whose X session lives in a non-default profile got silently wrong or missing cookies with zero indication why. Now scans every sibling profile in order, returns the first with a complete pair. Also fixes the case where every profile fails to even load (e.g. keychain access denied) — that's a distinct, more actionable error than "no session found."

- **CLI exit codes** — `add_cookie`/`add_cookie_local` logged failures but returned exit 0, so a script/agent checking `$?` would read a failed cookie setup as success. Both now `sys.exit(1)` on validation or extraction failure.

- **Quote-stripping in `parse_cookies`** — some cookie-export tools/extensions quote values (`auth_token="xxx"`); the literal quotes were kept as part of the cookie value, silently corrupting auth with no hint why.

- **CLI aliases** — `del_account`/`del_accounts` and `add_cookie`/`add_cookies` both work now; hit this exact typo trap while testing.

Also added `AGENTS.md` and expanded the cookie-setup section of the readme, since several of these failure modes cost real time to diagnose and are worth documenting for the next person (human or agent) hitting them.

## Test plan

- [x] Full suite: 213/213 pass (`pytest tests/`)
- [x] `ruff check` clean
- [x] Live end-to-end against a real x.com session: `add_cookie_local` → live validation → `search`/`user_by_login`/`user_tweets`/`followers` all succeeded
- [x] Multi-profile fix verified against a real 6-profile Chrome install, plus unit tests simulating the exact bug (session in non-Default profile, all-profiles-fail case)
- [x] Exit-code fix verified live (`echo $?` after real failures)

🤖 Generated with [Claude Code](https://claude.com/claude-code)