### PR TITLE
fix: Deduplicate yielded items across pages of a paginated crawl

### DIFF
--- a/tests/test_pagination.py
+++ b/tests/test_pagination.py
@@ -2,6 +2,8 @@
 Regression tests for pagination bugs:
   - #265 / #247: followers() / following() stops early when X returns a promo-only page
     (all entries have entryId starting with "who-to-follow-", leaving els=[] after filter)
+  - duplicate items across pages (e.g. pinned tweet repeated on page 1 and at its
+    chronological position) must be yielded only once per call
 """
 
 import json
@@ -9,6 +11,7 @@ import os
 
 from twscrape import API, gather
 from twscrape.queue_client import QueueClient
+from twscrape.utils import find_obj
 
 BASE_DIR = os.path.dirname(__file__)
 DATA_DIR = os.path.join(BASE_DIR, "mocked-data")
@@ -128,6 +131,39 @@ async def test_followers_stops_after_too_many_consecutive_empty_pages(monkeypatc
 
     assert len(users) == 0
     assert idx < 10, f"too many requests ({idx}); should have stopped after a few empty pages"
+
+
+async def test_user_tweets_dedup_across_pages(monkeypatch, api_mock: API):
+    """user_tweets() must yield a tweet once even if it appears on several pages
+    (e.g. the pinned tweet shows up on page 1 and again at its chronological position)."""
+    with open(os.path.join(DATA_DIR, "raw_user_tweets.json")) as f:
+        page1 = json.load(f)
+
+    # page 2 repeats the same tweets under a fresh cursor
+    page2 = json.loads(json.dumps(page1))
+    cur = find_obj(page2, lambda x: x.get("cursorType") == "Bottom")
+    assert cur is not None
+    cur["value"] = "page2-cursor"
+
+    pages = [page1, page2]
+    idx = 0
+
+    async def mock_get(self, url, params=None):
+        nonlocal idx
+        if idx >= len(pages):
+            return None
+        data = pages[idx]
+        idx += 1
+        return FakeRep(data)
+
+    monkeypatch.setattr(QueueClient, "get", mock_get)
+
+    tweets = await gather(api_mock.user_tweets(123))
+    ids = [x.id for x in tweets]
+
+    assert idx == 2, "both pages should be fetched"
+    assert len(ids) > 0, "expected tweets from page 1"
+    assert len(ids) == len(set(ids)), "a tweet repeated across pages must be yielded once"
 
 
 async def test_gql_items_stops_on_repeated_cursor(monkeypatch, api_mock: API):

--- a/twscrape/api.py
+++ b/twscrape/api.py
@@ -1,4 +1,5 @@
 from contextlib import aclosing
+from functools import wraps
 from typing import Literal
 
 from .accounts_pool import AccountsPool
@@ -94,6 +95,22 @@ GQL_FEATURES = {  # search values here (view source) https://x.com/
 
 KV = dict | None
 TrendId = Literal["trending", "news", "sport", "entertainment"] | str
+
+
+def _dedup_by_id(fn):
+    # X can return the same item on several pages of one crawl (e.g. UserTweets
+    # repeats the pinned tweet on page 1 and at its chronological position).
+    # parse_* dedups only within a single page, so dedup across pages here.
+    @wraps(fn)
+    async def wrapped(*args, **kwargs):
+        seen = set()
+        async with aclosing(fn(*args, **kwargs)) as gen:
+            async for x in gen:
+                if x.id not in seen:
+                    seen.add(x.id)
+                    yield x
+
+    return wrapped
 
 
 class API:
@@ -250,12 +267,14 @@ class API:
             async for x in gen:
                 yield x
 
+    @_dedup_by_id
     async def search(self, q: str, limit=-1, kv: KV = None):
         async with aclosing(self.search_raw(q, limit=limit, kv=kv)) as gen:
             async for rep in gen:
                 for x in parse_tweets(rep.json(), limit):
                     yield x
 
+    @_dedup_by_id
     async def search_user(self, q: str, limit=-1, kv: KV = None):
         kv = {"product": "People", **(kv or {})}
         async with aclosing(self.search_raw(q, limit=limit, kv=kv)) as gen:
@@ -361,6 +380,7 @@ class API:
             async for x in gen:
                 yield x
 
+    @_dedup_by_id
     async def tweet_replies(self, twid: int, limit=-1, kv: KV = None):
         async with aclosing(self.tweet_replies_raw(twid, limit=limit, kv=kv)) as gen:
             async for rep in gen:
@@ -424,6 +444,7 @@ class API:
             async for x in gen:
                 yield x
 
+    @_dedup_by_id
     async def tweet_thread(self, twid: int, limit=-1, kv: KV = None):
         async with aclosing(self.tweet_thread_raw(twid, limit=limit, kv=kv)) as gen:
             async for rep in gen:
@@ -441,6 +462,7 @@ class API:
             async for x in gen:
                 yield x
 
+    @_dedup_by_id
     async def followers(self, uid: int, limit=-1, kv: KV = None):
         async with aclosing(self.followers_raw(uid, limit=limit, kv=kv)) as gen:
             async for rep in gen:
@@ -459,6 +481,7 @@ class API:
             async for x in gen:
                 yield x
 
+    @_dedup_by_id
     async def verified_followers(self, uid: int, limit=-1, kv: KV = None):
         async with aclosing(self.verified_followers_raw(uid, limit=limit, kv=kv)) as gen:
             async for rep in gen:
@@ -474,6 +497,7 @@ class API:
             async for x in gen:
                 yield x
 
+    @_dedup_by_id
     async def following(self, uid: int, limit=-1, kv: KV = None):
         async with aclosing(self.following_raw(uid, limit=limit, kv=kv)) as gen:
             async for rep in gen:
@@ -489,6 +513,7 @@ class API:
             async for x in gen:
                 yield x
 
+    @_dedup_by_id
     async def subscriptions(self, uid: int, limit=-1, kv: KV = None):
         async with aclosing(self.subscriptions_raw(uid, limit=limit, kv=kv)) as gen:
             async for rep in gen:
@@ -504,6 +529,7 @@ class API:
             async for x in gen:
                 yield x
 
+    @_dedup_by_id
     async def retweeters(self, twid: int, limit=-1, kv: KV = None):
         async with aclosing(self.retweeters_raw(twid, limit=limit, kv=kv)) as gen:
             async for rep in gen:
@@ -527,6 +553,7 @@ class API:
             async for x in gen:
                 yield x
 
+    @_dedup_by_id
     async def user_tweets(self, uid: int, limit=-1, kv: KV = None):
         async with aclosing(self.user_tweets_raw(uid, limit=limit, kv=kv)) as gen:
             async for rep in gen:
@@ -550,6 +577,7 @@ class API:
             async for x in gen:
                 yield x
 
+    @_dedup_by_id
     async def user_tweets_and_replies(self, uid: int, limit=-1, kv: KV = None):
         async with aclosing(self.user_tweets_and_replies_raw(uid, limit=limit, kv=kv)) as gen:
             async for rep in gen:
@@ -575,6 +603,7 @@ class API:
             async for x in gen:
                 yield x
 
+    @_dedup_by_id
     async def user_media(self, uid: int, limit=-1, kv: KV = None):
         async with aclosing(self.user_media_raw(uid, limit=limit, kv=kv)) as gen:
             async for rep in gen:
@@ -598,6 +627,7 @@ class API:
             async for x in gen:
                 yield x
 
+    @_dedup_by_id
     async def list_timeline(self, list_id: int, limit=-1, kv: KV = None):
         async with aclosing(self.list_timeline_raw(list_id, limit=limit, kv=kv)) as gen:
             async for rep in gen:
@@ -626,12 +656,14 @@ class API:
             async for x in gen:
                 yield x
 
+    @_dedup_by_id
     async def trends(self, trend_id: TrendId, limit=-1, kv: KV = None):
         async with aclosing(self.trends_raw(trend_id, limit=limit, kv=kv)) as gen:
             async for rep in gen:
                 for x in parse_trends(rep, limit):
                     yield x
 
+    @_dedup_by_id
     async def search_trend(self, q: str, limit=-1, kv: KV = None):
         kv = {
             "querySource": "trend_click",
@@ -662,6 +694,7 @@ class API:
             async for x in gen:
                 yield x
 
+    @_dedup_by_id
     async def bookmarks(self, limit=-1, kv: KV = None):
         async with aclosing(self.bookmarks_raw(limit=limit, kv=kv)) as gen:
             async for rep in gen:
@@ -677,6 +710,7 @@ class API:
             async for page in gen:
                 yield page
 
+    @_dedup_by_id
     async def list_members(self, list_id: int, limit: int = -1, kv: KV = None):
         async with aclosing(self.list_members_raw(list_id, limit=limit, kv=kv)) as gen:
             async for page in gen:
@@ -697,6 +731,7 @@ class API:
             async for x in gen:
                 yield x
 
+    @_dedup_by_id
     async def community_members(self, community_id: int, limit=-1, kv: KV = None):
         async with aclosing(self.community_members_raw(community_id, limit=limit, kv=kv)) as gen:
             async for rep in gen:
@@ -717,6 +752,7 @@ class API:
             async for x in gen:
                 yield x
 
+    @_dedup_by_id
     async def community_moderators(self, community_id: int, limit=-1, kv: KV = None):
         async with aclosing(self.community_moderators_raw(community_id, limit=limit, kv=kv)) as gen:
             async for rep in gen:
@@ -743,6 +779,7 @@ class API:
             async for x in gen:
                 yield x
 
+    @_dedup_by_id
     async def community_tweets(self, community_id: int, limit=-1, kv: KV = None):
         async with aclosing(self.community_tweets_raw(community_id, limit=limit, kv=kv)) as gen:
             async for rep in gen:


### PR DESCRIPTION
# Fix: deduplicate yielded items across pages of a paginated crawl

## Problem

Generators like `api.user_tweets()` can yield the same tweet more than once per call. Dedup currently exists only inside the per-page parser (`_parse_items` in `models.py` keeps a local `ids` set), and that set is re-created for every page, so nothing prevents a duplicate spanning two pages.

Reproducible example: X's `UserTweets` page 1 contains the pinned tweet as an extra entry. If the tweet's chronological position falls on a later page, it is yielded once on page 1 and again on its own page. The same happens for any tweet embedded in several pages (quoted by two different tweets, shown in two conversation modules, etc.).

Callers reasonably expect each item at most once per crawl, so this is a bugfix. It still is a behaviour change though.

## Fix

Confined to `api.py`: a small `_dedup_by_id` decorator wraps each public item-yielding generator (`search`, `user_tweets`, `user_tweets_and_replies`, `tweet_replies`, `list_timeline`, `followers`, ...). It keeps one `seen` set for the lifetime of the generator call and skips any item whose `.id` was already yielded. Every item kind (Tweet, User, Trend) exposes `.id` (the existing per-page dedup already relies on it), so no type special-casing is needed.

The `*_raw` methods are untouched: they yield raw page responses, where duplicates are part of the actual API payload.

The per-page `ids` set in `_parse_items` is now redundant for these code paths but is left in place: removing it would change `parse_tweets` / `parse_users` behaviour for direct callers.

## Trade-off

The `seen` set grows with crawl size. Irrelevant for user timelines (X serves ~3200 tweets max), but a worst-case unbounded `search()` crawl now holds every yielded id in memory, roughly tens of MB per million items.

## Test

`tests/test_pagination.py::test_user_tweets_dedup_across_pages`: serves two mocked pages sharing the same tweet ids (second page under a fresh cursor so stall detection doesn't kick in), asserts both pages are fetched and every id is yielded exactly once.