### PR TITLE
Add a "Reactivate" command

### DIFF
--- a/tests/test_pool.py
+++ b/tests/test_pool.py
@@ -268,6 +268,19 @@ async def test_mark_inactive(pool_mock: AccountsPool):
     assert acc.error_msg == "banned by system"
 
 
+async def test_reactivate(pool_mock: AccountsPool):
+    await pool_mock.add_account("user1", "pass1", "email1", "ep1")
+    await pool_mock.mark_inactive("user1", "banned by system")
+
+    await pool_mock.reactivate("user1")
+    acc = await pool_mock.get("user1")
+    assert acc.active is True
+    assert acc.error_msg is None
+
+    # unknown username is a warning, not an error
+    await pool_mock.reactivate("nope")
+
+
 async def test_next_available_at_none_when_empty(pool_mock: AccountsPool):
     assert await pool_mock.next_available_at("TestQueue") is None
 

--- a/twscrape/accounts_pool.py
+++ b/twscrape/accounts_pool.py
@@ -390,6 +390,19 @@ class AccountsPool:
         """
         await execute(self._db_file, qs, {"username": username, "error_msg": error_msg})
 
+    async def reactivate(self, username: str):
+        rs = await self.get_account(username)
+        if rs is None:
+            logger.warning(f"Account {username} not found")
+            return
+
+        qs = """
+        UPDATE accounts SET active = true, error_msg = NULL
+        WHERE username = :username
+        """
+        await execute(self._db_file, qs, {"username": username})
+        logger.info(f"Account {username} reactivated")
+
     async def stats(self):
         def locks_count(queue: str):
             return f"""

--- a/twscrape/cli.py
+++ b/twscrape/cli.py
@@ -119,6 +119,10 @@ async def main(args):
         await pool.delete_inactive()
         return
 
+    if args.command == "reactivate":
+        await pool.reactivate(args.username)
+        return
+
     fn = args.command + "_raw" if args.raw else args.command
     fn = getattr(api, fn, None)
     if fn is None:
@@ -208,6 +212,9 @@ def run():
 
     subparsers.add_parser("reset_locks", help="Reset all locks")
     subparsers.add_parser("delete_inactive", help="Delete inactive accounts")
+
+    reactivate = subparsers.add_parser("reactivate", help="Mark an account as active again")
+    reactivate.add_argument("username", help="Username of the account to reactivate")
 
     c_lim("search", "Search for tweets", "query", "Search query")
     c_one("tweet_details", "Get tweet details", "tweet_id", "Tweet ID", int)


### PR DESCRIPTION
Yesterday I had quite a lot of accounts switching to Active 0 with a warning: `twscrape.queue_client:_check_rep:280 - Session expired or banned: 403 - -1/-1 - [ACCOUNT_HANDLE] - OK`. But a few hours later when I realized, I re-activate them manually and they all work. So I thought that this command can come handy instead of having to update them with SQL in the sqlite db.